### PR TITLE
If developer_mode=1, show fieldname as tooltip for all the users and not only Administrator

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -14,8 +14,7 @@ frappe.ui.form.Control = Class.extend({
 		this.make();
 
 		// if developer_mode=1, show fieldname as tooltip
-		if(frappe.boot.user && frappe.boot.user.name==="Administrator" &&
-			frappe.boot.developer_mode===1 && this.$wrapper) {
+		if(frappe.boot.user && frappe.boot.developer_mode===1 && this.$wrapper) {
 			this.$wrapper.attr("title", __(this.df.fieldname));
 		}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8912289/39740386-02707f82-52b3-11e8-9ae0-c227203b8211.png)
