### PR TITLE
Remove uri encoding from search results

### DIFF
--- a/frappe/templates/includes/search_box.html
+++ b/frappe/templates/includes/search_box.html
@@ -16,7 +16,7 @@
 frappe.ready(function() {
 	if(frappe.utils.get_url_arg("search")) {
 		var txt = frappe.utils.get_url_arg("search");
-		$(".item-search-results").html("{{ _('Search results for') }}: " + encodeURIComponent(txt));
+		$(".item-search-results").html("{{ _('Search results for') }}: " + txt);
 		$(".item-search").toggle(false);
 		$(".clear").toggle(true);
 	}

--- a/frappe/templates/includes/search_box.html
+++ b/frappe/templates/includes/search_box.html
@@ -15,8 +15,7 @@
 <script>
 frappe.ready(function() {
 	if(frappe.utils.get_url_arg("search")) {
-		var txt = frappe.utils.get_url_arg("search");
-		$(".item-search-results").html("{{ _('Search results for') }}: " + txt);
+		$(".item-search-results").html('{{ _("Search results for") + ": " + html2text(frappe.form_dict.search or "")|trim }}');
 		$(".item-search").toggle(false);
 		$(".clear").toggle(true);
 	}


### PR DESCRIPTION
Issue: The search strings on the website were encoded and displayed, for example, maple "leaf", displayed as maple%20%22leaf%22
![image](https://user-images.githubusercontent.com/8912289/40650602-4f786214-6351-11e8-95f8-767ccc22cf6e.png)

Solution: Remove uri encoding form search string.
![image](https://user-images.githubusercontent.com/8912289/40650688-81414a90-6351-11e8-80dc-74b28effbd30.png)

Related to: [https://github.com/frappe/erpnext/pull/14266](https://github.com/frappe/erpnext/pull/14266)
