### PR TITLE
fix(chart): Set chart bug for reports with values as an object

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -476,11 +476,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	get_possible_chart_options() {
 		const columns = this.raw_data.columns;
 		const rows =  this.raw_data.result;
-		const first_row = rows[0];
 		const has_total_row = this.raw_data.add_total_row;
+		const first_row = Array.isArray(rows[0]) ? rows[0] : Object.values(rows[0]);
 
 		const indices = first_row.reduce((accumulator, current_value, current_index) => {
-			if(!isNaN(Number(current_value))) {
+			if (Number.isFinite(current_value)) {
 				accumulator.push(current_index);
 			}
 			return accumulator;


### PR DESCRIPTION
**Problem:**

When trying to set a chart for a report, Frappe tries to separate numeric and non-numeric fields to show options for the axes using the data in the first row. Sometimes, the first row gets set as an object, which breaks that function.

**Traceback:**

```diff
Uncaught TypeError: n.reduce is not a function
    at frappe.views.QueryReport.get_possible_chart_options (query_report.js:482)
    at query_report.js:124
    at HTMLButtonElement.i (page.js:371)
    at HTMLButtonElement.dispatch (jquery.min.js:3)
    at HTMLButtonElement.r.handle (jquery.min.js:3)
    at HTMLButtonElement.d (raven.js:393)
```

**Solution:**

If the first row's data is an object, convert the values into an array.

**Additional fix:** When separating the fields into numeric and non-numeric, the check was allowing strings with numeric value ("1020") to be passed into the numeric fields.