### PR TITLE
fix: Small preventative check for accept header value missing

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -140,7 +140,7 @@ def handle_exception(e):
 	http_status_code = getattr(e, "http_status_code", 500)
 	return_as_message = False
 
-	if frappe.local.is_ajax or 'application/json' in frappe.get_request_header('Accept'):
+	if frappe.local.is_ajax or 'application/json' in frappe.get_request_header('Accept', ''):
 		# handle ajax responses first
 		# if the request is ajax, send back the trace or error message
 		response = frappe.utils.response.report_error(http_status_code)


### PR DESCRIPTION
Only going on a hunch. It seems to me that if the header "Accept" isn't set by the browser the second part of this if statement will error out with an invalid key on None object error. Saw something similar on the logs while hunting for a related error. This small change makes is so that we are not checking against a none value.