### PR TITLE
fix(timeline): Render links in Comment-type communications

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -376,7 +376,6 @@ frappe.ui.form.Timeline = class Timeline {
 					@abc with the below line of code.
 				*/
 
-				c.content_html = c.content_html.replace(/(<[a][^>]*>)/g, "");
 				// bold the @mentions
 				c.content_html = c.content_html.replace(/(@[^\s@]*)@[^\s@|<]*/g, "<b>$1</b>");
 			}


### PR DESCRIPTION
**Ref:** [TASK-2019-00151](https://digithinkit.global/desk#Form/Task/TASK-2019-00151)

<hr>

**Problem:**
Whenever a link is posted in a document's comments, the system doesn't render it as a link. This is because the form renderer removes anchor tags from the content.

**Solution:** (needs discussion)
We've removed the hardcode replace of anchor tags to let Comment-type communications to render in the document timeline.