### PR TITLE
fix: Fixes route rewrite issue causing dynamic links on addresses to disappear

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -184,7 +184,10 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			throw "saving";
 		}
 
-		frappe.ui.form.remove_old_form_route();
+		// ensure we remove new docs routes ONLY
+		if ( frm.is_new() ) {
+			frappe.ui.form.remove_old_form_route();
+		}
 		frappe.ui.form.is_saving = true;
 
 		return frappe.call({
@@ -218,14 +221,9 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 }
 
 frappe.ui.form.remove_old_form_route = () => {
-	let index = -1;
-	let current_route = frappe.get_route();
-	frappe.route_history.map((arr, i) => {
-		if (arr.join("/") === current_route.join("/")) {
-			index = i;
-		}
-	});
-	frappe.route_history.splice(index, 1);
+	let current_route = frappe.get_route().join("/");
+	frappe.route_history = frappe.route_history
+		.filter((route) => route.join("/") !== current_route);
 }
 
 frappe.ui.form.update_calling_link = (newdoc) => {


### PR DESCRIPTION
Fixes Angie's issue where address doctype would sometimes not populate the customer dynamic link table.

To reproduce:

- Go to existing customer
- Change any field so "Save" button is enabled and click Save
- Click "New Address"
- New Address form appears
- Dynamic link table now doesn't populate the customer this address should have been linked to

This also fixes routes in general all calls to "Save" removed the last route in memory