### PR TITLE
fix(naming): Keep naming series number on document deletion to maintain data integrity

### DIFF
--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -53,18 +53,6 @@ class TestEvent(unittest.TestCase):
 		self.assertFalse("_Test Event 3" in subjects)
 		self.assertFalse("_Test Event 2" in subjects)
 
-	def test_revert_logic(self):
-		ev = frappe.get_doc(self.test_records[0]).insert()
-		name = ev.name
-
-		frappe.delete_doc("Event", ev.name)
-
-		# insert again
-		ev = frappe.get_doc(self.test_records[0]).insert()
-
-		# the name should be same!
-		self.assertEqual(ev.name, name)
-
 	def test_assign(self):
 		from frappe.desk.form.assign_to import add
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -10,7 +10,6 @@ import frappe.defaults
 from frappe.utils.file_manager import remove_all
 from frappe.utils.password import delete_all_passwords_for
 from frappe import _
-from frappe.model.naming import revert_series_if_last
 from frappe.utils.global_search import delete_for_document
 from six import string_types, integer_types
 
@@ -87,7 +86,6 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 					check_if_doc_is_linked(doc)
 					check_if_doc_is_dynamically_linked(doc)
 
-			update_naming_series(doc)
 			delete_from_table(doctype, name, ignore_doctypes, doc)
 			doc.run_method("after_delete")
 
@@ -119,15 +117,6 @@ def add_to_deleted_document(doc):
 			data=doc.as_json(),
 			owner=frappe.session.user
 		)).db_insert()
-
-def update_naming_series(doc):
-	if doc.meta.autoname:
-		if doc.meta.autoname.startswith("naming_series:") \
-			and getattr(doc, "naming_series", None):
-			revert_series_if_last(doc.naming_series, doc.name)
-
-		elif doc.meta.autoname.split(":")[0] not in ("Prompt", "field", "hash"):
-			revert_series_if_last(doc.meta.autoname, doc.name)
 
 def delete_from_table(doctype, name, ignore_doctypes, doc):
 	if doctype!="DocType" and doctype==name:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -169,24 +169,6 @@ def getseries(key, digits, doctype=''):
 	return ('%0'+str(digits)+'d') % current
 
 
-def revert_series_if_last(key, name):
-	if ".#" in key:
-		prefix, hashes = key.rsplit(".", 1)
-		if "#" not in hashes:
-			return
-	else:
-		prefix = key
-
-	if '.' in prefix:
-		prefix = parse_naming_series(prefix.split('.'))
-
-	count = cint(name.replace(prefix, ""))
-	current = frappe.db.sql("select `current` from `tabSeries` where name=%s for update", (prefix,))
-
-	if current and current[0][0]==count:
-		frappe.db.sql("update tabSeries set current=current-1 where name=%s", prefix)
-
-
 def get_default_naming_series(doctype):
 	"""get default value for `naming_series` property"""
 	naming_series = frappe.get_meta(doctype).get_field("naming_series").options or ""

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -13,7 +13,6 @@ import frappe.utils.scheduler
 import cProfile, pstats
 from six import StringIO
 from six.moves import reload_module
-from frappe.model.naming import revert_series_if_last
 
 unittest_runner = unittest.TextTestRunner
 
@@ -319,11 +318,6 @@ def make_test_objects(doctype, test_records=None, verbose=None, reset=False):
 	'''Make test objects from given list of `test_records` or from `test_records.json`'''
 	records = []
 
-	def revert_naming(d):
-		if getattr(d, 'naming_series', None):
-			revert_series_if_last(d.naming_series, d.name)
-
-
 	if test_records is None:
 		test_records = frappe.get_test_records(doctype)
 
@@ -358,15 +352,8 @@ def make_test_objects(doctype, test_records=None, verbose=None, reset=False):
 
 			if docstatus == 1:
 				d.submit()
-
-		except frappe.NameError:
-			revert_naming(d)
-
 		except Exception as e:
-			if d.flags.ignore_these_exceptions_in_test and e.__class__ in d.flags.ignore_these_exceptions_in_test:
-				revert_naming(d)
-			else:
-				raise
+			raise
 
 		records.append(d.name)
 

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -345,15 +345,11 @@ def make_test_objects(doctype, test_records=None, verbose=None, reset=False):
 		docstatus = d.docstatus
 
 		d.docstatus = 0
+		d.run_method("before_test_insert")
+		d.insert()
 
-		try:
-			d.run_method("before_test_insert")
-			d.insert()
-
-			if docstatus == 1:
-				d.submit()
-		except Exception as e:
-			raise
+		if docstatus == 1:
+			d.submit()
 
 		records.append(d.name)
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -6,8 +6,6 @@ import os
 import unittest
 
 import frappe
-from frappe.utils import cint
-from frappe.utils.testutils import add_custom_field, clear_custom_fields
 
 
 class TestDocument(unittest.TestCase):
@@ -221,20 +219,3 @@ class TestDocument(unittest.TestCase):
 		after_update = frappe.db.get_value(doctype, name, 'idx')
 
 		self.assertEqual(before_update + new_count, after_update)
-
-	def test_default_of_dependent_field(self):
-		add_custom_field('ToDo', 'parent_field', 'Data')
-
-		add_custom_field('ToDo', 'dependent_field', 'Data',
-			default='Some Data', depends_on='parent_field')
-
-		add_custom_field('ToDo', 'independent_field', 'Data',
-			default='Some Data')
-
-
-		doc = frappe.new_doc('ToDo')
-
-		self.assertFalse(doc.get('dependent_field'))
-		self.assertEqual(doc.get('independent_field'), 'Some Data')
-
-		clear_custom_fields('ToDo')

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -7,7 +7,7 @@ import frappe
 from frappe.utils import now_datetime
 
 from frappe.model.naming import getseries
-from frappe.model.naming import append_number_if_name_exists, revert_series_if_last
+from frappe.model.naming import append_number_if_name_exists
 
 class TestNaming(unittest.TestCase):
 	def tearDown(self):
@@ -60,37 +60,3 @@ class TestNaming(unittest.TestCase):
 
 		self.assertEqual(todo.name, 'TODO-{month}-{status}-{series}'.format(
 			month=now_datetime().strftime('%m'), status=todo.status, series=series))
-
-	def test_revert_series(self):
-		from datetime import datetime
-		year = datetime.now().year
-
-		series = 'TEST-{}-'.format(year)
-		key = 'TEST-.YYYY.-'
-		name = 'TEST-{}-00001'.format(year)
-		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 1)""", (series,))
-		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
-
-		self.assertEqual(count.get('current'), 0)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
-
-		series = 'TEST-{}-'.format(year)
-		key = 'TEST-.YYYY.-.#####'
-		name = 'TEST-{}-00002'.format(year)
-		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 2)""", (series,))
-		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
-
-		self.assertEqual(count.get('current'), 1)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
-
-		series = 'TEST-'
-		key = 'TEST-'
-		name = 'TEST-00003'
-		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
-		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
-
-		self.assertEqual(count.get('current'), 2)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)


### PR DESCRIPTION
**Ref:** [TASK-2019-00280](https://digithinkit.global/desk#Form/Task/TASK-2019-00280)

Related to https://github.com/DigiThinkIT/erpnext/pull/208.

<hr>

**Reason:**

Whenever a document is created and then deleted, it resets the naming series to the previous numbering.

This can get problematic for a number of scenarios - say, for example, an Email Alert for new Sales Orders sends out the document in an email as reference. However, in case this order is deleted, and a new one created for a different Customer, it'll still have the name of the deleted document, which is bad practice.

By not unsetting the naming series whenever a document is deleted, and generate new names for each transaction / document, we avoid the issue entirely.