### PR TITLE
fix: Frappe fails to install with pip newer than v9.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,14 @@ import os, shutil
 from distutils.command.clean import clean as Clean
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip < 10
+    from pip.req import parse_requirements
+except ImportError: # for pip >= 10
+    def parse_requirements(filename):
+        """ load requirements from a pip requirements file """
+        lineiter = (line.strip() for line in open(filename))
+        return [line for line in lineiter if line and not line.startswith("#")]
+
 import re, ast
 
 # get version from __version__ variable in frappe/__init__.py


### PR DESCRIPTION
This adds an alternative parse_requirements method removed on pip >= v10

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.