### PR TITLE
fix: takes care of extra deprecated arguments on parse_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 try: # for pip < 10
     from pip.req import parse_requirements
 except ImportError: # for pip >= 10
-    def parse_requirements(filename):
+    def parse_requirements(filename, **kwargs):
         """ load requirements from a pip requirements file """
         lineiter = (line.strip() for line in open(filename))
         return [line for line in lineiter if line and not line.startswith("#")]


### PR DESCRIPTION
Quick fix on extra unused arguments to match old parse_requirements method

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.