### PR TITLE
fix: requirements key missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError: # for pip >= 10
     def parse_requirements(filename, **kwargs):
         """ load requirements from a pip requirements file """
         lineiter = (line.strip() for line in open(filename))
-        return [line for line in lineiter if line and not line.startswith("#")]
+        return [{ "req": line, "_link": false} for line in lineiter if line and not line.startswith("#")]
 
 import re, ast
 


### PR DESCRIPTION
Added missing key on parse_requirements results

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.