### PR TITLE
fix: merge conflict

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -732,8 +732,7 @@ _f.Frm.prototype._save = function(save_action, callback, btn, on_error, resolve,
 		}
 
 		callback && callback(r);
-		// chains the save promise with add new comment promise
-		resolve(add_new_comment);
+		resolve();
 	};
 
 	var fail = () => {


### PR DESCRIPTION
JS keeps failing at `add_new_comment` not defined, since it was removed in one of the merges.