### PR TITLE
feat: allow extending doctype dashboards via hooks

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -197,12 +197,7 @@ class FormMeta(Meta):
 	def load_dashboard(self):
 		if self.custom:
 			return
-
-		dashboard_data = self.get_dashboard_data()
-		for hook in frappe.get_hooks("override_doctype_dashboards", {}).get(self.name, []):
-			dashboard_data = frappe.get_attr(hook)(data=dashboard_data)
-
-		self.set('__dashboard', dashboard_data)
+		self.set('__dashboard', self.get_dashboard_data())
 
 	def load_kanban_meta(self):
 		self.load_kanban_column_fields()

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -200,8 +200,7 @@ class FormMeta(Meta):
 
 		dashboard_data = self.get_dashboard_data()
 		for hook in frappe.get_hooks("override_doctype_dashboards", {}).get(self.name, []):
-			dashboard_data = frappe.get_attr(hook)()
-			break
+			dashboard_data = frappe.get_attr(hook)(data=dashboard_data)
 
 		self.set('__dashboard', dashboard_data)
 

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -197,7 +197,13 @@ class FormMeta(Meta):
 	def load_dashboard(self):
 		if self.custom:
 			return
-		self.set('__dashboard', self.get_dashboard_data())
+
+		dashboard_data = self.get_dashboard_data()
+		for hook in frappe.get_hooks("override_doctype_dashboards", {}).get(self.name, []):
+			dashboard_data = frappe.get_attr(hook)()
+			break
+
+		self.set('__dashboard', dashboard_data)
 
 	def load_kanban_meta(self):
 		self.load_kanban_column_fields()
@@ -232,4 +238,3 @@ def get_js(path):
 	js = frappe.read_file(path)
 	if js:
 		return render_include(js)
-

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -409,8 +409,10 @@ class Meta(Document):
 	def get_dashboard_data(self):
 		'''Returns dashboard setup related to this doctype.
 
-		This method will return the `data` property in the
-		`[doctype]_dashboard.py` file in the doctype folder'''
+		This method will return the `data` property in the `[doctype]_dashboard.py`
+		file in the doctype's folder, along with any overrides or extensions
+		implemented in other Frappe applications.
+		'''
 		data = frappe._dict()
 		try:
 			module = load_doctype_module(self.name, suffix='_dashboard')
@@ -418,6 +420,9 @@ class Meta(Document):
 				data = frappe._dict(module.get_data())
 		except ImportError:
 			pass
+
+		for hook in frappe.get_hooks("override_doctype_dashboards", {}).get(self.name, []):
+			data = frappe.get_attr(hook)(data=data)
 
 		return data
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -411,7 +411,7 @@ class Meta(Document):
 
 		This method will return the `data` property in the `[doctype]_dashboard.py`
 		file in the doctype's folder, along with any overrides or extensions
-		implemented in other Frappe applications.
+		implemented in other Frappe applications via hooks.
 		'''
 		data = frappe._dict()
 		try:

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -242,11 +242,15 @@ app_license = "{app_license}"
 
 # before_tests = "{app_name}.install.before_tests"
 
-# Overriding Whitelisted Methods
+# Overriding Methods
 # ------------------------------
 #
 # override_whitelisted_methods = {{
 # 	"frappe.desk.doctype.event.event.get_events": "{app_name}.event.get_events"
+# }}
+#
+# override_doctype_dashboards = {{
+# 	"Task": "{app_name}.task.get_dashboard_data"
 # }}
 
 """

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -249,6 +249,9 @@ app_license = "{app_license}"
 # 	"frappe.desk.doctype.event.event.get_events": "{app_name}.event.get_events"
 # }}
 #
+# each overriding function accepts a `data` argument;
+# generated from the base implementation of the doctype dashboard,
+# along with any modifications made in other Frappe apps
 # override_doctype_dashboards = {{
 # 	"Task": "{app_name}.task.get_dashboard_data"
 # }}


### PR DESCRIPTION
**Ref:** [TASK-2019-00607](https://digithinkit.global/desk#Form/Task/TASK-2019-00607)

<hr>

**Changes:**
- New `override_doctype_dashboards` configuration available in every app's hooks file.
  - Each configuration is a key-value pair mapping the target DocType (for which the dashboard needs to be overridden) to a target Python function.
  - Multiple apps can inherit `data` from the previous app, whether available or not, so modifications can be handled separately in each app.

**Example:**
In the `hooks.py` file of your app:

```python
override_doctype_dashboards = {
    "Task": "{your_app_name}.task.get_dashboard_data"
}
```

In that app's `task.py`:

```python

# the `data` argument is generated first at the doctype-level,
# and passed along to the next app to be modified
def get_dashboard_data(data):
    # make your changes here
	return data
```

<hr>

**Screenshots / GIFs:**

**Before:**

![image](https://user-images.githubusercontent.com/13396535/64166224-520ac600-ce64-11e9-8437-27624041ad05.png)

**After:**

![image](https://user-images.githubusercontent.com/13396535/64166289-664ec300-ce64-11e9-8116-2cf4e1ea0251.png)