### PR TITLE
fix: auto email report delivery

### DIFF
--- a/frappe/templates/emails/auto_email_report.html
+++ b/frappe/templates/emails/auto_email_report.html
@@ -39,7 +39,8 @@
 					</td>
 				{% else %}
 					<td {{- get_alignment(col) }}>
-						{% if col.fieldtype == "Link" and col.options %}
+						<!-- TODO: Fixed in v12; remove after upgrade -->
+						{% if col.fieldtype == "Link" and col.options and row[col.fieldname] %}
 							{{- frappe.utils.get_link_to_form(col.options, row[col.fieldname]) }}
 						{% else %}
 							{{- frappe.format(row[col.fieldname], col, row) -}}


### PR DESCRIPTION
Refs:

- [TASK-2019-00757](https://digithinkit.global/desk#Form/Task/TASK-2019-00757)
- https://sentry.io/organizations/bloomstack/issues/1300381520/?project=1278577&query=is%3Aunresolved&statsPeriod=14d

<hr>

The cell was empty, so Frappe wasn't able to generate a hyperlink when creating the auto email report using NoneType data.