### PR TITLE
fix: build filter metadata before allowing user to send email

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -78,6 +78,9 @@ frappe.ui.form.on('Auto Email Report', {
 
 			if(report_filters && report_filters.length > 0) {
 				frm.set_value('filter_meta', JSON.stringify(report_filters));
+				if (frm.is_dirty()) {
+					frm.save();
+				}
 			}
 
 			var report_filters_list = []


### PR DESCRIPTION
Refs:

- [TASK-2019-00758](https://digithinkit.global/desk#Form/Task/TASK-2019-00758)
- https://sentry.io/organizations/bloomstack/issues/1300380828/?project=1278577&query=is%3Aunresolved&statsPeriod=14d

<hr>

Frappe actually DOES a check for unset filters before letting the user proceed, but it fails to update the database with the required data (it saves the document first to get report metadata, and then builds the necessary filter data /shrug). We now do a check for unsaved changes and update the database by saving the document again.

<hr>

**Screenshots / GIFs:**

![auto-email-fix](https://user-images.githubusercontent.com/13396535/67747151-2cf29800-fa4e-11e9-8f54-daf03e11db5d.gif)