### PR TITLE
fix: remove trailing slash from releaserc

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
     "branch" : "bloomstack-production",
-    "repositoryUrl" : "https://github.com/digithinkit/frappe/",
+    "repositoryUrl" : "https://github.com/digithinkit/frappe",
     "plugins" : ["@semantic-release/commit-analyzer", "@semantic-release/release-notes-generator", "@semantic-release/github"]
 }


### PR DESCRIPTION
a semantic-release release broke our pipeline because there was a trailing slash :man_shrugging:

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.