### PR TITLE
feat(core): auto-cancel linked documents on cancelling a document

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -291,7 +291,7 @@ def get_dynamic_linked_fields(doctype, without_ignore_user_permissions_enabled=F
 		if is_single(df.doctype): continue
 
 		# removed doctype_fieldname form fields it only check with child with parenttype
-		possible_link = frappe.get_all(df.doctype, filters={df.doctype_fieldname: doctype}, fields=['parenttype'])
+		possible_link = frappe.get_all(df.doctype, filters={df.doctype_fieldname: doctype}, fields=['parenttype'], distinct=True)
 		if not possible_link: continue
 
 		for d in possible_link:

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -15,6 +15,20 @@ from frappe.modules import load_doctype_module
 
 @frappe.whitelist()
 def get_submitted_linked_docs(doctype, name, docs=None):
+	"""
+	Get all nested submitted linked doctype linkinfo
+
+	Arguments:
+		doctype (str) - The doctype for which get all linked doctypes
+		name (str) - The docname for which get all linked doctypes
+
+	Keyword Arguments:
+		docs [list of dict] - (Optional) Get list of dictionary for linked doctype (default: None)
+
+	Returns:
+		dict - Return list of documents and link count
+	"""
+
 	if not docs:
 		docs = []
 
@@ -52,6 +66,13 @@ def get_submitted_linked_docs(doctype, name, docs=None):
 
 @frappe.whitelist()
 def cancel_all_linked_docs(docs):
+	"""
+	Cancel all linked doctype
+
+	Arguments:
+		docs [list of dict] - It contains all list of dictionaries of a linked documents.
+	"""
+
 	docs = json.loads(docs)
 	for i, doc in enumerate(docs, 1):
 		if validate_linked_doc(doc) is True:

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -70,7 +70,7 @@ def cancel_all_linked_docs(docs):
 	Cancel all linked doctype
 
 	Arguments:
-		docs [list of dict] - It contains all list of dictionaries of a linked documents.
+		docs (str) - JSON string containg list of all linked documents.
 	"""
 
 	docs = json.loads(docs)

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -2,13 +2,72 @@
 # MIT License. See license.txt
 from __future__ import unicode_literals
 
-import frappe, json
+import json
+from collections import defaultdict
+
+from six import string_types
+
+import frappe
+import frappe.desk.form.load
+import frappe.desk.form.meta
+from frappe import _
 from frappe.model.meta import is_single
 from frappe.modules import load_doctype_module
-import frappe.desk.form.meta
-import frappe.desk.form.load
-from six import string_types
-from collections import defaultdict
+
+
+@frappe.whitelist()
+def get_submitted_linked_docs(doctype, name, docs=None):
+	if not docs:
+		docs = []
+
+	linkinfo = get_linked_doctypes(doctype)
+	linked_docs = get_linked_docs(doctype, name, linkinfo)
+
+	link_count = 0
+	CANCEL_EXEMPT_DOCTYPES = []
+
+	for doctype in frappe.get_hooks('cancel_exempt_doctypes'):
+		CANCEL_EXEMPT_DOCTYPES.extend(doctype)
+
+	for link_doctype, link_names in linked_docs.items():
+		# skip non-submittable doctypes since they don't need to be cancelled
+		if not frappe.get_meta(link_doctype).is_submittable:
+			continue
+
+		# skip other doctypes since they don't need to be cancelled
+		if link_doctype in CANCEL_EXEMPT_DOCTYPES:
+			continue
+
+		for link in link_names:
+			if link.docstatus != 1:
+				continue
+
+			link_count += 1
+			if link.name in [doc.get("name") for doc in docs]:
+				continue
+
+			links = get_submitted_linked_docs(link_doctype, link.name, docs)
+			docs.append({
+				"doctype": link_doctype,
+				"name": link.name,
+				"link_count": links.get("count")
+			})
+
+	# sort linked documents by ascending number of links
+	docs.sort(key=lambda doc: doc.get("link_count"))
+	return {
+		"docs": docs,
+		"count": link_count
+	}
+
+
+@frappe.whitelist()
+def cancel_all_linked_docs(docs):
+	docs = json.loads(docs)
+	for i, doc in enumerate(docs, 1):
+		frappe.publish_progress(percent=i * 100 / len(docs), title=_("Cancelling documents"))
+		linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
+		linked_doc.cancel()
 
 
 @frappe.whitelist()

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -23,7 +23,7 @@ def get_submitted_linked_docs(doctype, name, docs=None):
 		name (str) - The docname for which get all linked doctypes
 
 	Keyword Arguments:
-		docs [list of dict] - (Optional) Get list of dictionary for linked doctype (default: None)
+		docs (list of dict) - (Optional) Get list of dictionary for linked doctype.
 
 	Returns:
 		dict - Return list of documents and link count
@@ -70,7 +70,7 @@ def cancel_all_linked_docs(docs):
 	Cancel all linked doctype
 
 	Arguments:
-		docs (str) - JSON string containg list of all linked documents.
+		docs (str) - JSON string containing list of all linked documents.
 	"""
 
 	docs = json.loads(docs)
@@ -110,7 +110,7 @@ def validate_linked_doc(docinfo):
 
 def get_exempted_doctypes():
 	"""
-		Get list of doctypes exempted from being auto-cancelled
+	Get list of doctypes exempted from being auto-cancelled
 	"""
 
 	auto_cancel_exempt_doctypes = []
@@ -290,10 +290,8 @@ def get_dynamic_linked_fields(doctype, without_ignore_user_permissions_enabled=F
 	for df in links:
 		if is_single(df.doctype): continue
 
-		# optimized to get both link exists and parenttype
-		possible_link = frappe.db.sql("""select distinct `{doctype_fieldname}`, parenttype
-			from `tab{doctype}` where `{doctype_fieldname}`=%s""".format(**df), doctype, as_dict=True)
-
+		# removed doctype_fieldname form fields it only check with child with parenttype
+		possible_link = frappe.get_all(df.doctype, filters={df.doctype_fieldname: doctype}, fields=['parenttype'])
 		if not possible_link: continue
 
 		for d in possible_link:

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -805,10 +805,9 @@ _f.Frm.prototype.savesubmit = function(btn, callback, on_error) {
 	});
 };
 
-_f.Frm.prototype.savecancel = function(btn, callback, on_error) {
-	var me = this;
-
-	let handle_fail = () => {
+_f.Frm.prototype.savecancel = function (btn, callback, on_error) {
+	const me = this;
+	const handle_fail = () => {
 		$(btn).prop('disabled', false);
 		if (on_error) {
 			on_error();
@@ -816,16 +815,93 @@ _f.Frm.prototype.savecancel = function(btn, callback, on_error) {
 	};
 
 	this.validate_form_action('Cancel');
-	frappe.confirm(__("Permanently Cancel {0}?", [this.docname]), function() {
+
+	frappe.call({
+		method: "frappe.desk.form.linked_with.get_submitted_linked_docs",
+		args: {
+			doctype: me.doc.doctype,
+			name: me.doc.name
+		},
+		freeze: true,
+		callback: (r) => {
+			if (!r.exc && r.message.count > 0) {
+				me._cancel_all(r, btn, callback, handle_fail);
+			} else {
+				me._cancel(btn, callback, handle_fail, false);
+			}
+		}
+	});
+};
+
+_f.Frm.prototype._cancel_all = function (r, btn, callback, handle_fail) {
+	const me = this;
+
+	// add confirmation message for cancelling all linked docs
+	let links_text = "";
+	let links = r.message.docs;
+	const doctypes = Array.from(new Set(links.map(link => link.doctype)));
+
+	for (let doctype of doctypes) {
+		let docnames = links
+			.filter((link) => link.doctype == doctype)
+			.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
+			.join(", ");
+		links_text += `<li><strong>${doctype}</strong>: ${docnames}</li>`
+	}
+	links_text = "<ul>" + links_text + "</ul>"
+
+	let confirm_message = `<strong>${me.doc.doctype}</strong> ${me.doc.name} is linked with the following submitted documents: ${links_text}`
+	let can_cancel = links.every((link) => frappe.model.can_cancel(link.doctype));
+	if (can_cancel) {
+		confirm_message += `Do you want to cancel all linked documents?`;
+	} else {
+		confirm_message += `You do not have permissions to cancel all linked documents.`;
+	}
+
+	// generate dialog box to cancel all linked docs
+	let d = new frappe.ui.Dialog({
+		title: __("Cancel All Documents"),
+		fields: [{
+			fieldtype: "HTML",
+			options: `<p class="frappe-confirm-message">${confirm_message}</p>`
+		}]
+	}, () => handle_fail());
+
+	// if user can cancel all linked docs, add action to the dialog
+	if (can_cancel) {
+		d.set_primary_action("Cancel All", () => {
+			d.hide();
+			frappe.call({
+				method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
+				args: {
+					docs: links
+				},
+				freeze: true,
+				callback: (resp) => {
+					if (!resp.exc) {
+						me.reload_doc();
+						me._cancel(btn, callback, handle_fail, true);
+					}
+				}
+			})
+		});
+	}
+
+	d.show();
+};
+
+_f.Frm.prototype._cancel = function (btn, callback, handle_fail, skip_confirm) {
+	const me = this;
+	const cancel_doc = () => {
 		frappe.validated = true;
-		me.script_manager.trigger("before_cancel").then(function() {
-			if(!frappe.validated) {
+		me.script_manager.trigger("before_cancel").then(function () {
+			if (!frappe.validated) {
 				handle_fail();
 				return;
 			}
 
-			var after_cancel = function(r) {
-				if(r.exc) {
+			const after_cancel = function (r) {
+				if (r.exc) {
 					handle_fail();
 				} else {
 					frappe.utils.play_sound("cancel");
@@ -836,7 +912,13 @@ _f.Frm.prototype.savecancel = function(btn, callback, on_error) {
 			};
 			frappe.ui.form.save(me, "cancel", after_cancel, btn);
 		});
-	}, () => handle_fail());
+	}
+
+	if (skip_confirm) {
+		cancel_doc();
+	} else {
+		frappe.confirm(__("Permanently Cancel {0}?", [this.docname]), cancel_doc, handle_fail);
+	}
 };
 
 // delete the record

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -256,6 +256,15 @@ app_license = "{app_license}"
 # 	"Task": "{app_name}.task.get_dashboard_data"
 # }}
 
+
+
+# Exempt doctype for cancel
+# -----------------------
+#
+# cancel_exempt_doctypes = [
+#	"Payment Entry"
+# ]
+
 """
 
 desktop_template = """# -*- coding: utf-8 -*-

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -261,9 +261,7 @@ app_license = "{app_license}"
 # Exempt doctype for cancel
 # -----------------------
 #
-# cancel_exempt_doctypes = [
-#	"Payment Entry"
-# ]
+# auto_cancel_exempt_doctypes = ["Auto Repeat"]
 
 """
 


### PR DESCRIPTION
Task: [TASK-2019-00760](https://digithinkit.global/desk#Form/Task/TASK-2019-00760)

**Screenshots / GIFs:**
Usecase: 
As a User, I want to be able to delete the linked document to the one I'm trying to delete, so that I don't have to manually delete the document(s) 

Problem: 
Anytime you try to cancel a document that is linked somewhere else, it doesn't allow you to do so. Which is obviously a good thing to maintain data integrity. However, we should allow the User to cancel both the documents on another button click, whilst warning them of the consequences.

Solution:

![cancel](https://user-images.githubusercontent.com/6947417/69704034-b31b0080-1118-11ea-834c-1474aee76a69.gif)

Pull Request Depends on : https://github.com/DigiThinkIT/erpnext/pull/264

ToDo:

- [x] Recursively find linked submittable documents.
- [x] Check is user can cancel all docs, only then show "Cancel All" button.
- [x] If user can cancel all docs, first cancel linked docs and then come back to cancel current doc.
- [x] If errors are thrown during validation, rollback already cancelled docs.
- [x] Remove non-submittable doctypes from view.
- [x] Improve cancel message.
