### PR TITLE
fix: missing column data for Kanban board

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -108,6 +108,11 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		});
 	}
 
+	get_fields() {
+		this.fields.push([this.board.field_name, this.board.reference_doctype]);
+		return super.get_fields();
+	}
+
 	render() {
 		const board_name = this.board_name;
 		if (this.kanban && board_name === this.kanban.board_name) {


### PR DESCRIPTION
**Problem:**

If a particular column is selected for a Kanban board that is not available in the list view, no cards populate on the board itself.

<hr>

**Screenshots / GIFs:**

**Before:**

![image](https://user-images.githubusercontent.com/13396535/71892660-89b9af80-316f-11ea-9a45-f710f2572b7b.png)

**After:**

![image](https://user-images.githubusercontent.com/13396535/71892644-7dcded80-316f-11ea-809e-5db3e0b8ba7d.png)