### PR TITLE
fix: update rq dependency for redis upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ bleach==2.1.4
 bleach-whitelist
 Pillow
 beautifulsoup4
-rq==0.12.0
+rq>=1.1.0
 schedule
 cryptography
 pyopenssl


### PR DESCRIPTION
**Problem:**

The system was erroring out while trying to create Error Logs due to an RQ dependency problem with redis-python >=3.0