### PR TITLE
fix: py3 compatibility for error snapshot creation

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -128,14 +128,14 @@ def get_snapshot(exception, context=10):
 				value = pydoc.text.repr(getattr(evalue, name))
 
 				# render multilingual string properly
-				if type(value)==str and value.startswith(b"u'"):
+				if type(value) == str and value.startswith("u'"):
 					value = eval(value)
 
 				s['exception'][name] = encode(value)
 
 	# add all local values (of last frame) to the snapshot
 	for name, value in locals.items():
-		if type(value)==str and value.startswith(b"u'"):
+		if type(value) == str and value.startswith("u'"):
 			value = eval(value)
 
 		s['locals'][name] = pydoc.text.repr(value)


### PR DESCRIPTION
**Ref:** https://sentry.io/organizations/bloomstack/issues/1458651520/?project=1476365&query=is%3Aunresolved

<hr>

```python
TypeError: startswith first arg must be str or a tuple of str, not bytes
  File "frappe/utils/error.py", line 36, in make_error_snapshot
    snapshot = get_snapshot(exception)
  File "frappe/utils/error.py", line 131, in get_snapshot
    if type(value)==str and value.startswith(b"u'"):
```