### PR TITLE
fix: hide calender menu if it is not set

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -160,7 +160,7 @@ frappe.views.ListSidebar = class ListSidebar {
 				reference_doctype: doctype
 			}
 		}).then(result => {
-			if (!result.length) return;
+			if (!(result && result.length)) return;
 			const calendar_views = result;
 			const $link_calendar = this.sidebar.find('.list-link[data-view="Calendar"]');
 

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -160,7 +160,7 @@ frappe.views.ListSidebar = class ListSidebar {
 				reference_doctype: doctype
 			}
 		}).then(result => {
-			if (!(result && result.length)) return;
+			if (!(result && Array.isArray(result) && result.length)) return;
 			const calendar_views = result;
 			const $link_calendar = this.sidebar.find('.list-link[data-view="Calendar"]');
 

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -160,7 +160,7 @@ frappe.views.ListSidebar = class ListSidebar {
 				reference_doctype: doctype
 			}
 		}).then(result => {
-			if (!result) return;
+			if (!result.length) return;
 			const calendar_views = result;
 			const $link_calendar = this.sidebar.find('.list-link[data-view="Calendar"]');
 

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -351,6 +351,9 @@ frappe.views.Calendar = Class.extend({
 
 			me.fix_end_date_for_event_render(d);
 			me.prepare_colors(d);
+
+			d.title = frappe.utils.html2text(d.title);
+			
 			return d;
 		});
 	},


### PR DESCRIPTION
before 
![oVE38Qq](https://user-images.githubusercontent.com/60173537/73332045-a4bda200-428b-11ea-9811-d47722390b4c.png)

after:
![Peek 2020-01-29 11-37](https://user-images.githubusercontent.com/60173537/73332138-d6cf0400-428b-11ea-82a3-82e7738c014e.gif)
