### PR TITLE
fix: Pins Werkzeug version to 0.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ maxminddb-geolite2
 python-dateutil
 pytz
 six
-werkzeug
+werkzeug==0.16.0
 semantic_version
 rauth>=0.6.2
 requests


### PR DESCRIPTION
Fixes issue where frappe doesn't have a pinned version of werkzeug. A newer version will break frappe as of now:

https://discuss.erpnext.com/t/frappe-web-wont-start/57885/4

There is already a fix on develop branch making its way to a release to change Werkzeug to version 1.0.0
For now this patch solves short term issues with installing new bench/frappe instances

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
