### PR TITLE
fix: allow edit settings in Web Form

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -20,7 +20,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	make() {
 		super.make();
 		this.set_field_values();
-		this.set_editable_values();
+		this.toggle_form_edit();
 		if (this.introduction_text) this.set_form_description(this.introduction_text);
 		if (this.allow_print && !this.is_new) this.setup_print_button();
 		if (this.allow_delete && !this.is_new) this.setup_delete_button();
@@ -45,7 +45,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		else return;
 	}
 
-	set_editable_values() {
+	toggle_form_edit() {
 		if (!this.is_new && this.allow_edit === 0) {
 			this.fields.map(field => this.set_df_property(field.fieldname, "read_only", 1));
 		}

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -20,6 +20,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	make() {
 		super.make();
 		this.set_field_values();
+		this.set_editable_values();
 		if (this.introduction_text) this.set_form_description(this.introduction_text);
 		if (this.allow_print && !this.is_new) this.setup_print_button();
 		if (this.allow_delete && !this.is_new) this.setup_delete_button();
@@ -42,6 +43,12 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	set_field_values() {
 		if (this.doc.name) this.set_values(this.doc);
 		else return;
+	}
+
+	set_editable_values() {
+		if (!this.is_new && this.allow_edit === 0) {
+			this.fields.map(field => this.set_df_property(field.fieldname, "read_only", 1));
+		}
 	}
 
 	set_default_values() {

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -51,14 +51,8 @@ frappe.ready(function() {
 		get_data().then(r => {
 			const data = setup_fields(r.message);
 			let web_form_doc = data.web_form;
-
-			if (web_form_doc.name && web_form_doc.allow_edit === 0) {
-				if (!window.location.href.includes("?new=1")) {
-					window.location.replace(window.location.pathname + "?new=1");
-				}
-			}
 			let doc = r.message.doc || build_doc(r.message);
-			web_form.prepare(web_form_doc, r.message.doc && web_form_doc.allow_edit === 1 ? r.message.doc : {});
+			web_form.prepare(web_form_doc, doc);
 			web_form.make();
 			web_form.set_default_values();
 		})

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -61,14 +61,14 @@ data-web-form="{{ name }}" data-web-form-doctype="{{ doc_type }}" data-login-req
 	</div>
 	{% endif %} {# attachments #}
 
-	{% if allow_comments and not frappe.form_dict.new and not is_list -%}
+	{% if allow_comments and not frappe.form_dict.new -%}
 	<div class="comments">
 		<h3>{{ _("Comments") }}</h3>
 		{% include 'templates/includes/comments/comments.html' %}
 	</div>
 	{%- endif %} {# comments #}
-
 	{% endif %}
+
 </div>
 {% endblock page_content %}
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -137,23 +137,19 @@ def get_context(context):
 		if self.is_standard:
 			self.use_meta_fields()
 
-		if not context._login_required:
-			if self.allow_edit:
-				if self.allow_multiple:
-					if not frappe.form_dict.name and not frappe.form_dict.new:
-						# list data is queried via JS
-						context.is_list = True
-				else:
-					if frappe.session.user != 'Guest' and not frappe.form_dict.name:
-						frappe.form_dict.name = frappe.db.get_value(self.doc_type, {"owner": frappe.session.user}, "name")
+		if self.allow_multiple:
+			if not frappe.form_dict.name and not frappe.form_dict.new:
+				# list data is queried via JS
+				context.is_list = True
 
-					if not frappe.form_dict.name:
-						# only a single doc allowed and no existing doc, hence new
-						frappe.form_dict.new = 1
+		if not self.login_required:
+			if not self.allow_multiple:
+				if frappe.session.user != 'Guest' and not frappe.form_dict.name:
+					frappe.form_dict.name = frappe.db.get_value(self.doc_type, {"owner": frappe.session.user}, "name")
 
-		# always render new form if login is not required or doesn't allow editing existing ones
-		if not self.login_required or not self.allow_edit:
-			frappe.form_dict.new = 1
+				if not frappe.form_dict.name:
+					# only a single doc allowed and no existing doc, hence new
+					frappe.form_dict.new = 1
 
 		self.load_document(context)
 		context.parents = self.get_parents(context)
@@ -589,4 +585,3 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 
 	else:
 		raise frappe.PermissionError('Not Allowed, {0}'.format(doctype))
-


### PR DESCRIPTION
**Ref:** [TASK-2020-00162](https://corp.bloomstack.com/desk#Form/Task/TASK-2020-00162)

<hr>

**Changes:**

- With "Allow Edit" unchecked:
  - **Before** - The portal would not show any existing documents, and always default to a new form
  - **After** - The portal now shows the listing of any existing documents, but the user is not able to edit any of them (they can still comment if the web form allows for it)