### PR TITLE
feat: Adds small improvements to chat notifications

### DIFF
--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1582,7 +1582,7 @@ class extends Component {
 				frappe.notify(`${frappe.user.first_name(r.user)}`, {
 					body: r.content,
 					icon: frappe.user.image(r.user),
-					requireInteraction: true
+					tag: r.user
 				})
 			}
 

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1566,14 +1566,23 @@ class extends Component {
 				const  alert   = // TODO: ellipses content
 				`
 				<span data-action="show-message" class="cursor-pointer">
-					<span class="indicator yellow"/> <b>${frappe.user.first_name(r.user)}</b>: ${r.content}
+					<span class="indicator yellow"/>
+						<span class="avatar avatar-small">
+							<span class="avatar-frame" style="background-image: url(&quot;${frappe.user.image(r.user)}&quot;)"></span>
+						</span>
+						<b>${frappe.user.first_name(r.user)}</b>: ${r.content}
 				</span>
 				`
-				frappe.show_alert(alert, 3, {
+				frappe.show_alert(alert, 15, {
 					"show-message": function (r) {
 						this.room.select(r.room)
 						this.base.firstChild._component.toggle()
 					}.bind(this, r)
+				})
+				frappe.notify(`${frappe.user.first_name(r.user)}`, {
+					body: r.content,
+					icon: frappe.user.image(r.user),
+					requireInteraction: true
 				})
 			}
 


### PR DESCRIPTION
Changes:

- sets chat desk notification to 15 seconds as users tend to miss the current quick notification.
- includes sender's avatar on the desk alert message

Additions:

- adds a web notification to chat messages upon receiving them. It includes the sender's avatar, name and message. This feature is only visible on HTTPs requests due to Notifaction api restrictions.
![chat-notification-feature](https://user-images.githubusercontent.com/1656249/77591919-6c22f900-6ec7-11ea-9164-b7e53ebe6858.gif)
