### PR TITLE
fix: fixed the reports print format

### DIFF
--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -145,6 +145,11 @@ table.no-border, table.no-border td {
 	margin: 3px 0px 3px;
 }
 
+.print-format table td pre {
+	white-space: normal;
+	word-break: normal;
+}
+
 table td div {
 	{% if not print_settings.allow_page_break_inside_tables %}
 	/* needed to avoid partial cutting of text between page break in wkhtmltopdf */


### PR DESCRIPTION
**Task Link:** https://bloomstack.com/desk#Form/Task/TASK-2020-00317

**Description:** The print for the reports looked distorted. It's fixed.

**Screenshots:
Before:**
![Screenshot from 2020-05-11 18-22-24](https://user-images.githubusercontent.com/45919049/81564336-32457d80-93b5-11ea-94da-7ecd87ed18e3.png)

**After:**
![Screenshot from 2020-05-11 18-24-51](https://user-images.githubusercontent.com/45919049/81564353-383b5e80-93b5-11ea-8749-7383db08c975.png)
