### PR TITLE
feat: allow mapper functions to be overriden

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -14,6 +14,12 @@ def make_mapped_doc(method, source_name, selected_children=None, args=None):
 	Sets selected_children as flags for the `get_mapped_doc` method.
 
 	Called from `open_mapped_doc` from create_new.js'''
+
+	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(method, []):
+		# override using the first hook
+		method = hook
+		break
+
 	method = frappe.get_attr(method)
 
 	if method not in frappe.whitelisted:


### PR DESCRIPTION
**Problem:**

Functions called by the mapper helper (`open_mapped_doc`) could not be overriden using hooks

**Solution:**

Added a handler to check for `override_whitelisted_methods` while mapping documents