### PR TITLE
fix: web form fails to inform users on validation errors

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -35,6 +35,7 @@
 		"public/js/frappe/utils/pretty_date.js",
 		"public/js/frappe/microtemplate.js",
 		"public/js/frappe/query_string.js",
+		"public/js/frappe/request.js",
 
 		"public/js/frappe/ui/dropzone.js",
 		"public/js/frappe/ui/upload.html",

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -374,6 +374,38 @@ export default {
 								indicator: 'red',
 								message: response._error_message
 							});
+						} else if ( xhr.status === 417) {
+							file.failed = true;
+							let error = null;
+							try {
+								error = JSON.parse(xhr.responseText);
+							} catch(e) {
+								// pass
+							}
+
+							if ( error._server_messages) {
+								try {
+									for(let msg of JSON.parse(error._server_messages)) {
+										if ( typeof msg === 'string' ) {
+											msg = JSON.parse(msg);
+										}
+										frappe.msgprint({
+											title: __("Validation Error"),
+											indicator: msg.indicator || 'red',
+											message: msg.message
+										});
+									}
+								} catch(e) {
+									// pass
+								}
+							} else {
+								frappe.msgprint({
+									title: __("Unexpected Validation Error"),
+									indicator: 'red',
+									message: __("There was an error uploading your file.")
+								});
+							}
+
 						} else {
 							file.failed = true;
 							let error = null;

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -142,15 +142,17 @@ export default class WebForm extends frappe.ui.FieldGroup {
 					this.handle_success(response.message);
 					frappe.web_form.events.trigger('after_save');
 					// args doctype and docname added to link doctype in file manager
-					frappe.call({
-						type: 'POST',
-						method: "frappe.handler.upload_file",
-						args: {
-							file_url: response.message.attachment,
-							doctype: response.message.doctype,
-							docname: response.message.name
-						}
-					});
+					if ( response.message.attachment ) {
+						frappe.call({
+							type: 'POST',
+							method: "frappe.handler.upload_file",
+							args: {
+								file_url: response.message.attachment,
+								doctype: response.message.doctype,
+								docname: response.message.name
+							}
+						});
+					}
 				}
 			},
 			always: function() {


### PR DESCRIPTION
REF: [TASK-2020-01115](https://bloomstack.com/desk#Form/Task/TASK-2020-01115)

During file uploads with invalid file types.

Additionally uploading files with the vue file uploader fails to attach files to doctypes on webforms and erroneously tries to attach empty data to the doctype.

This last issue needs more thinking about the flow of the uploader as the webform client side expects the server to return the attached file once it send the webform data. However, the server makes no attempt to attach a file linked on an Attach field by value instead of data.

