### PR TITLE
feat: Removes desk title for loading...

### DIFF
--- a/frappe/www/desk.html
+++ b/frappe/www/desk.html
@@ -14,7 +14,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="white">
 	<meta name="mobile-web-app-capable" content="yes">
-	<title>Frappe Desk</title>
+	<title>Loading...</title>
 	<link rel="shortcut icon"
 		href="{{ favicon or "/assets/frappe/images/favicon.png" }}" type="image/x-icon">
 	<link rel="icon"


### PR DESCRIPTION
The desk always shows frappe during loading and eventually changes to whatever the backend's name is set.