### PR TITLE
fix: Jinja index starts at 1, bootstrap carousel expects start at 0

### DIFF
--- a/frappe/templates/includes/slideshow.html
+++ b/frappe/templates/includes/slideshow.html
@@ -6,8 +6,8 @@
 	<!-- Indicators -->
 	<ol class="carousel-indicators">
 		{% for slide in slides %}
-		<li data-target="#the-carousel" data-slide-to="{{ loop.index }}"
-			{%- if loop.index==0 %}class="active"{% endif %}></li>
+		<li data-target="#the-carousel" data-slide-to="{{ loop.index0 }}"
+			{%- if loop.index0==0 %}class="active"{% endif %}></li>
 		{% endfor %}
 	</ol>
 	{% endif %}


### PR DESCRIPTION
Slide show index start at the wrong index causing first item to be skipped and links to be offset. This fixes that by re-indexing slides at index 0 as bootstrap carousel expects it.

[Asana Task: Pic banner functionality](https://app.asana.com/0/1188891334286761/1194966993809267/f)