### PR TITLE
feat: Adds on_session_start hook as soon as session data is ready

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -118,6 +118,9 @@ class LoginManager:
 				self.get_user_info()
 				self.make_session()
 				self.set_user_info()
+				
+		# run session start trigger. Different from creation as it happens on every request
+		self.run_trigger('on_session_start')
 
 	def login(self):
 		# clear cache


### PR DESCRIPTION
Adds a handy hook to manage extending session data as soon as it starts or its state is restored.