### PR TITLE
fix: timezone fixes

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -15,7 +15,7 @@ import frappe.permissions
 import frappe.share
 import re
 import json
-
+import frappe.defaults
 from frappe.website.utils import is_signup_enabled
 from frappe.utils.background_jobs import enqueue
 
@@ -101,6 +101,9 @@ class User(Document):
 		create_contact(self, ignore_mandatory=True)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:
 			frappe.enqueue('frappe.core.doctype.user.user.update_gravatar', name=self.name)
+
+		if self.time_zone:
+			frappe.defaults.set_default("time_zone", self.time_zone, self.name)
 
 	def has_website_permission(self, ptype, user, verbose=False):
 		"""Returns true if current user is the session user"""

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -20,6 +20,12 @@ frappe.ui.form.ControlDatetime = frappe.ui.form.ControlDate.extend({
 		this.$input && this.$input.val(this.format_for_input(value));
 		this.format_for_datepicker(value);
 	},
+	format_for_input: function(value) {
+		if(value) {
+			return frappe.datetime.str_to_user(value, false, true);
+		}
+		return "";
+	},
 	format_for_datepicker: function(value) {
 		if (!this.datepicker) return;
 		if(!value) {

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -12,15 +12,39 @@ frappe.ui.form.ControlDatetime = frappe.ui.form.ControlDate.extend({
 		return frappe.datetime.now_datetime(true);
 	},
 	set_description: function() {
-		const { description } = this.df;
-		const { time_zone } = frappe.sys_defaults;
-		if (!frappe.datetime.is_timezone_same()) {
-			if (!description) {
-				this.df.description = time_zone;
-			} else if (!description.includes(time_zone)) {
-				this.df.description += '<br>' + time_zone;
+		this.df.description = frappe.user_defaults.time_zone;
+		this._super();
+	},
+	set_formatted_input(value) {
+		value = frappe.datetime.convert_to_user_tz(value, true);
+		this.$input && this.$input.val(this.format_for_input(value));
+		this.format_for_datepicker(value);
+	},
+	format_for_datepicker: function(value) {
+		if (!this.datepicker) return;
+		if(!value) {
+			this.datepicker.clear();
+			return;
+		}
+
+		let should_refresh = this.last_value && this.last_value !== value;
+
+		if (!should_refresh) {
+			if(this.datepicker.selectedDates.length > 0) {
+				// if date is selected but different from value, refresh
+				const selected_date =
+					moment(this.datepicker.selectedDates[0])
+						.format(this.date_format);
+
+				should_refresh = selected_date !== value;
+			} else {
+				// if datepicker has no selected date, refresh
+				should_refresh = true;
 			}
 		}
-		this._super();
+
+		if(should_refresh) {
+			this.datepicker.selectDate(moment(value).format(frappe.defaultDatetimeFormat || "YYYY-MM-DD HH:mm:ss"));
+		}
 	}
 });

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -12,7 +12,7 @@ frappe.ui.form.ControlDatetime = frappe.ui.form.ControlDate.extend({
 		return frappe.datetime.now_datetime(true);
 	},
 	set_description: function() {
-		this.df.description = frappe.user_defaults.time_zone;
+		this.df.description = frappe.user_defaults.time_zone || frappe.sys_defaults.time_zone;
 		this._super();
 	},
 	set_formatted_input(value) {

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -154,15 +154,7 @@ frappe.form.formatters = {
 		}
 	},
 	Datetime: function(value) {
-		if(value) {
-			var m = moment(frappe.datetime.convert_to_user_tz(value));
-			if(frappe.boot.sysdefaults.time_zone) {
-				m = m.tz(frappe.boot.sysdefaults.time_zone);
-			}
-			return m.format(frappe.boot.sysdefaults.date_format.toUpperCase() + ', h:mm a z');
-		} else {
-			return "";
-		}
+		return value ? frappe.datetime.convert_to_user_tz(value, true) : "";
 	},
 	Text: function(value) {
 		if(value) {

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -168,7 +168,7 @@ $.extend(frappe.datetime, {
 	},
 
 	_date: function(format, as_obj = false) {
-		const time_zone = frappe.sys_defaults && frappe.sys_defaults.time_zone;
+		const time_zone = (frappe.user_defaults && frappe.user_defaults.time_zone) || (frappe.sys_defaults && frappe.sys_defaults.time_zone);
 		let date;
 		if (time_zone) {
 			date = moment.tz(time_zone);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,16 +3054,21 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
     minimist "0.0.8"
 
 moment-timezone@^0.5.21:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
-  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
+  version "0.5.31"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
+  integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.24.0, "moment@>= 2.9.0", moment@^2.20.1:
+moment@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+"moment@>= 2.9.0", moment@^2.20.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- The system only displays time form one timezone and it messes up for a user in another timezone.
- This becomes pretty evident in case of setting datetime in sensitive documents.