### PR TITLE
fix: make all upload files attachment as public by default.

### DIFF
--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -46,7 +46,7 @@ context('FileUploader', () => {
 		cy.route('POST', '/api/method/upload_file').as('upload_file');
 		cy.get_open_dialog().find('.btn-primary').click();
 		cy.wait('@upload_file').its('response.body.message')
-			.should('have.property', 'file_url', '/private/files/example.json');
+			.should('have.property', 'file_url', '/files/example.json');
 		cy.get('.modal:visible').should('not.exist');
 	});
 

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -225,7 +225,6 @@ export default {
 			let files = Array.from(file_array)
 				.filter(this.check_restrictions)
 				.map(file => {
-					let is_image = file.type.startsWith('image');
 					return {
 						file_obj: file,
 						name: file.name,
@@ -234,7 +233,7 @@ export default {
 						total: 0,
 						failed: false,
 						uploading: false,
-						private: !is_image
+						private: 0
 					}
 				});
 			this.files = this.files.concat(files);


### PR DESCRIPTION
Task ID: [Make Attachment Private if "Make all attachments private" check box has checked. 
By default the attachment should come as Public](https://bloomstack.com/desk#Form/Task/TASK-2020-01964)

before:
![Peek 2020-11-06 14-04](https://user-images.githubusercontent.com/6947417/98344326-19064c80-2039-11eb-9efa-0060eac8b62b.gif)


after:
![Peek 2020-11-06 14-01](https://user-images.githubusercontent.com/6947417/98343963-9a111400-2038-11eb-959b-59c856df7b68.gif)
