### PR TITLE
feat: Child Table fields in standard List view filters

### DIFF
--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -8,9 +8,13 @@
   "disable_count",
   "disable_sidebar_stats",
   "disable_auto_refresh",
+  "listview_fields_section",
   "total_fields",
   "fields_html",
-  "fields"
+  "fields",
+  "listview_filters_section",
+  "filters_html",
+  "filters"
  ],
  "fields": [
   {
@@ -40,7 +44,7 @@
   {
    "fieldname": "fields_html",
    "fieldtype": "HTML",
-   "label": "Fields"
+   "label": "ListView Fields"
   },
   {
    "fieldname": "fields",
@@ -48,9 +52,32 @@
    "hidden": 1,
    "label": "Fields",
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "listview_fields_section",
+   "fieldtype": "Section Break",
+   "label": "ListView Fields"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "listview_filters_section",
+   "fieldtype": "Section Break",
+   "label": "ListView Filters"
+  },
+  {
+   "fieldname": "filters_html",
+   "fieldtype": "HTML",
+   "label": "Filters HTML"
+  },
+  {
+   "fieldname": "filters",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Filters"
   }
  ],
- "modified": "2020-12-02 19:22:45.242469",
+ "modified": "2020-12-04 06:07:19.594538",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -12,10 +12,13 @@ class ListViewSettings(Document):
 		frappe.clear_document_cache(self.doctype, self.name)
 
 @frappe.whitelist()
-def save_listview_settings(doctype, listview_settings, removed_listview_fields):
+def save_listview_settings(doctype, listview_settings, removed_listview_attr):
 
 	listview_settings = frappe.parse_json(listview_settings)
-	removed_listview_fields = frappe.parse_json(removed_listview_fields)
+	removed_listview_attr = frappe.parse_json(removed_listview_attr)
+
+	removed_listview_fields = frappe.parse_json(removed_listview_attr.get("removed_listview_fields"))
+	removed_listview_filters = frappe.parse_json(removed_listview_attr.get("removed_listview_filters"))
 
 	if frappe.get_all("List View Settings", filters={"name": doctype}):
 		doc = frappe.get_doc("List View Settings", doctype)
@@ -28,6 +31,7 @@ def save_listview_settings(doctype, listview_settings, removed_listview_fields):
 		doc.insert()
 
 	set_listview_fields(doctype, listview_settings.get("fields"), removed_listview_fields)
+	set_listview_filters(listview_settings.get("filters"), removed_listview_filters)
 
 	return {
 		"meta": frappe.get_meta(doctype, False),
@@ -37,19 +41,27 @@ def save_listview_settings(doctype, listview_settings, removed_listview_fields):
 def set_listview_fields(doctype, listview_fields, removed_listview_fields):
 	meta = frappe.get_meta(doctype)
 
-	listview_fields = [f.get("fieldname") for f in frappe.parse_json(listview_fields) if f.get("fieldname")]
+	for field in frappe.parse_json(listview_fields):
+		set_property(doctype, meta.get_field(field.get("fieldname")), "in_list_view", "1")
 
-	for field in removed_listview_fields:
-		set_in_list_view_property(doctype, meta.get_field(field), "0")
+	for field in frappe.parse_json(removed_listview_fields):
+		set_property(doctype, meta.get_field(field), "in_list_view", "0")
 
-	for field in listview_fields:
-		set_in_list_view_property(doctype, meta.get_field(field), "1")
+def set_listview_filters(listview_filters, removed_listview_filters):
 
-def set_in_list_view_property(doctype, field, value):
+	for flt in frappe.parse_json(listview_filters):
+		meta = frappe.get_meta(flt.get("doctype"))
+		set_property(meta.name, meta.get_field(flt.get("fieldname")), "in_standard_filter", "1")
+
+	for flt in frappe.parse_json(removed_listview_filters):
+		meta = frappe.get_meta(flt.get("doctype"))
+		set_property(meta.name, meta.get_field(flt.get("fieldname")), "in_standard_filter", "0")
+
+def set_property(doctype, field, field_property, value):
 	if not field or field.fieldname == "status_field":
 		return
 
-	property_setter = frappe.db.get_value("Property Setter", {"doc_type": doctype, "field_name": field.fieldname, "property": "in_list_view"})
+	property_setter = frappe.db.get_value("Property Setter", {"doc_type": doctype, "field_name": field.fieldname, "property": field_property})
 	if property_setter:
 		doc = frappe.get_doc("Property Setter", property_setter)
 		doc.value = value
@@ -59,7 +71,7 @@ def set_in_list_view_property(doctype, field, value):
 			"doctype": doctype,
 			"doctype_or_field": "DocField",
 			"fieldname": field.fieldname,
-			"property": "in_list_view",
+			"property": field_property,
 			"value": value,
 			"property_type": "Check"
 		}, ignore_validate=True)
@@ -74,5 +86,26 @@ def get_default_listview_fields(doctype):
 
 	if meta.title_field and not meta.title_field.strip() in fields:
 			fields.append(meta.title_field.strip())
+
+	return {
+		doctype: fields
+	}
+
+@frappe.whitelist()
+def get_default_listview_filters(doctype):
+	meta = frappe.get_meta(doctype)
+	table_fields = meta.get_table_fields()
+
+	fields = {}
+
+	for meta in [meta] + table_fields:
+		if meta.doctype == "DocField":
+			meta = frappe.get_meta(meta.options)
+
+		path = frappe.get_module_path(frappe.scrub(meta.module), "doctype", frappe.scrub(meta.name),
+			frappe.scrub(meta.name) + ".json")
+		doctype_json = frappe.get_file_json(path)
+
+		fields[meta.name] = [f.get("fieldname") for f in doctype_json.get("fields") if f.get("in_standard_filter")]
 
 	return fields

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -446,12 +446,24 @@ frappe.ui.FilterArea = class FilterArea {
 		this.standard_filters_wrapper = this.list_view.page.page_form;
 		this.$filter_list_wrapper = $('<div class="filter-list">').appendTo(this.list_view.$frappe_list);
 		this.trigger_refresh = true;
+		this.filter_list = null;
 		this.setup();
 	}
 
-	setup() {
-		this.make_standard_filters();
-		this.make_filter_list();
+	setup(refresh_filters=false) {
+		if (refresh_filters) {
+			this.list_view.page.clear_fields();
+		}
+
+		if (this.has_custom_filters_config()) {
+			this.make_custom_filters();
+		} else {
+			this.make_standard_filters();
+		}
+
+		if (!this.filter_list) {
+			this.make_filter_list();
+		}
 	}
 
 	get() {
@@ -598,7 +610,7 @@ frappe.ui.FilterArea = class FilterArea {
 			}
 		];
 
-		if(this.list_view.custom_filter_configs) {
+		if (this.list_view.custom_filter_configs) {
 			this.list_view.custom_filter_configs.forEach(config => {
 				config.onchange = () => this.refresh_list_view();
 			});
@@ -631,6 +643,7 @@ frappe.ui.FilterArea = class FilterArea {
 				default_value = null;
 			}
 			return {
+				doctype: this.list_view.meta.name,
 				fieldtype: fieldtype,
 				label: __(df.label),
 				options: options,
@@ -646,9 +659,25 @@ frappe.ui.FilterArea = class FilterArea {
 		fields.map(df => this.list_view.page.add_field(df));
 	}
 
+	make_custom_filters() {
+		let fields = JSON.parse(this.list_view.list_view_settings.filters);
+
+		fields.forEach(field => {
+			field.onchange = () => this.refresh_list_view();
+		});
+
+		fields.map(df => this.list_view.page.add_field(df));
+	}
+
 	get_standard_filters() {
 		const filters = [];
 		const fields_dict = this.list_view.page.fields_dict;
+		let doc_type = "";
+		for (let key in fields_dict) {
+			if (fields_dict[key].df.doctype)
+				doc_type = fields_dict[key].df.doctype;
+		}
+
 		for (let key in fields_dict) {
 			let field = fields_dict[key];
 			let value = field.get_value();
@@ -657,7 +686,7 @@ frappe.ui.FilterArea = class FilterArea {
 					value = '%' + value + '%';
 				}
 				filters.push([
-					this.list_view.doctype,
+					doc_type,
 					field.df.fieldname,
 					field.df.condition || '=',
 					value
@@ -682,6 +711,14 @@ frappe.ui.FilterArea = class FilterArea {
 		// returns true if user is currently editing filters
 		return this.filter_list &&
 			this.filter_list.wrapper.find('.filter-box:visible').length > 0;
+	}
+
+	has_custom_filters_config() {
+		if (this.list_view.list_view_settings && this.list_view.list_view_settings.filters) {
+			return true;
+		}
+
+		return false;
 	}
 }
 

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -661,6 +661,13 @@ frappe.ui.FilterArea = class FilterArea {
 
 	make_custom_filters() {
 		let fields = JSON.parse(this.list_view.list_view_settings.filters);
+		fields.unshift({
+			doctype: this.list_view.doctype,
+			fieldtype: 'Data',
+			label: 'Name',
+			condition: 'like',
+			fieldname: 'name'
+		});
 
 		fields.forEach(field => {
 			field.onchange = () => this.refresh_list_view();
@@ -672,11 +679,6 @@ frappe.ui.FilterArea = class FilterArea {
 	get_standard_filters() {
 		const filters = [];
 		const fields_dict = this.list_view.page.fields_dict;
-		let doc_type = "";
-		for (let key in fields_dict) {
-			if (fields_dict[key].df.doctype)
-				doc_type = fields_dict[key].df.doctype;
-		}
 
 		for (let key in fields_dict) {
 			let field = fields_dict[key];
@@ -686,7 +688,7 @@ frappe.ui.FilterArea = class FilterArea {
 					value = '%' + value + '%';
 				}
 				filters.push([
-					doc_type,
+					this.list_view.doctype,
 					field.df.fieldname,
 					field.df.condition || '=',
 					value

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -10,14 +10,16 @@ export default class ListSettings {
 		this.settings = settings;
 		this.dialog = null;
 		this.fields = this.settings && this.settings.fields ? JSON.parse(this.settings.fields) : [];
+		this.filters = this.settings && this.settings.filters ? JSON.parse(this.settings.filters) : [];
 		this.subject_field = null;
+		this.removed_fields = [];
+		this.removed_filters = [];
 
 		frappe.model.with_doctype("List View Settings", () => {
 			this.make();
-			this.get_listview_fields(meta);
-			this.setup_fields();
-			this.setup_remove_fields();
-			this.add_new_fields();
+			this.set_listview_fields(meta);
+			this.set_listview_filters(meta);
+			this.refresh();
 			this.show_dialog();
 		});
 	}
@@ -45,24 +47,24 @@ export default class ListSettings {
 				args: {
 					doctype: me.doctype,
 					listview_settings: values,
-					removed_listview_fields: me.removed_fields || []
+					removed_listview_attr: {
+						"removed_listview_fields": me.removed_fields || [],
+						"removed_listview_filters": me.removed_filters || [],
+					}
 				},
 				callback: function (r) {
-					me.listview.refresh_columns(r.message.meta, r.message.listview_settings);
+					me.listview.refresh_fields(r.message.meta, r.message.listview_settings);
 					me.dialog.hide();
 				}
 			});
 		});
-
-		me.dialog.fields_dict["total_fields"].df.onchange = () => me.refresh();
 	}
 
 	refresh() {
 		let me = this;
 
-		me.setup_fields();
-		me.add_new_fields();
-		me.setup_remove_fields();
+		me.setup_listview_fields();
+		me.setup_listview_filters();
 	}
 
 	show_dialog() {
@@ -87,23 +89,26 @@ export default class ListSettings {
 		me.dialog.show();
 	}
 
-	setup_fields() {
-		function is_status_field(field) {
-			return field.fieldname === "status_field";
-		}
-
+	setup_listview_fields() {
 		let me = this;
+
+		me.dialog.fields_dict["total_fields"].df.onchange = () => me.setup_listview_fields();
 
 		let fields_html = me.dialog.get_field("fields_html");
 		let wrapper = fields_html.$wrapper[0];
 		let fields = ``;
 		let total_fields = me.dialog.get_values().total_fields || me.settings.total_fields;
 
+		let is_status_field = function (field) {
+			return field.fieldname === "status_field";
+		};
+
 		for (let idx in me.fields) {
 			if (idx == parseInt(total_fields)) {
 				break;
 			}
-			let is_sortable = (idx == 0) ? `` : `sortable`;
+
+			let is_sortable = (idx == 0) ? `` : `fields-sortable`;
 			let show_sortable_handle = (idx == 0) ? `hide` : ``;
 			let can_remove = (idx == 0 || is_status_field(me.fields[idx])) ? `hide` : ``;
 
@@ -113,7 +118,7 @@ export default class ListSettings {
 					data-label="${me.fields[idx].label}" data-type="${me.fields[idx].type}">
 					<div class="row">
 						<div class="col-md-1">
-							<i class="fa fa-bars text-muted sortable-handle ${show_sortable_handle}" aria-hidden="true"></i>
+							<i class="fa fa-bars text-muted fields-sortable-handle ${show_sortable_handle}" aria-hidden="true"></i>
 						</div>
 						<div class="col-md-10" style="padding-left:0px;">
 							${me.fields[idx].label}
@@ -130,9 +135,9 @@ export default class ListSettings {
 		fields_html.html(`
 			<div class="form-group">
 				<div class="clearfix">
-					<label class="control-label" style="padding-right: 0px;">Fields</label>
+					<label class="control-label" style="padding-right: 0px;">Listview Fields</label>
 				</div>
-				<div class="control-input-wrapper">
+				<div class="fields-control-input-wrapper">
 				${fields}
 				</div>
 				<p class="help-box small text-muted hidden-xs">
@@ -143,152 +148,382 @@ export default class ListSettings {
 			</div>
 		`);
 
-		new Sortable(wrapper.getElementsByClassName("control-input-wrapper")[0], {
-			handle: '.sortable-handle',
-			draggable: '.sortable',
+		new Sortable(wrapper.getElementsByClassName("fields-control-input-wrapper")[0], {
+			handle: '.fields-sortable-handle',
+			draggable: '.fields-sortable',
 			onUpdate: () => {
 				me.update_fields();
-				me.refresh();
+
+				// Refreshes the fields
+				me.setup_listview_fields();
 			}
 		});
-	}
-
-	add_new_fields() {
-		let me = this;
-
-		let fields_html = me.dialog.get_field("fields_html");
-		let add_new_fields = fields_html.$wrapper[0].getElementsByClassName("add-new-fields")[0];
-		add_new_fields.onclick = () => me.column_selector();
-	}
-
-	setup_remove_fields() {
-		let me = this;
-
-		let fields_html = me.dialog.get_field("fields_html");
+		// Delete field
 		let remove_fields = fields_html.$wrapper[0].getElementsByClassName("remove-field");
-
 		for (let idx = 0; idx < remove_fields.length; idx++) {
-			remove_fields.item(idx).onclick = () => me.remove_fields(remove_fields.item(idx).getAttribute("data-fieldname"));
+			remove_fields.item(idx).onclick = () => me.remove_listview_fields(remove_fields.item(idx).getAttribute("data-fieldname"));
 		}
+
+		// Fields selector
+		let reset_fields = "frappe.desk.doctype.list_view_settings.list_view_settings.get_default_listview_fields";
+		let active_fields = {};
+		active_fields[me.meta.name] = me.fields.map(f => f.fieldname);
+		let add_new_fields = fields_html.$wrapper[0].getElementsByClassName("add-new-fields")[0];
+		add_new_fields.onclick = () => {
+			me.fields_selector("for_list_fields", false, reset_fields, active_fields);
+		};
 	}
 
-	remove_fields(fieldname) {
+	setup_listview_filters() {
+
 		let me = this;
-		let existing_fields = me.fields.map(f => f.fieldname);
 
-		for (let idx in me.fields) {
-			let field = me.fields[idx];
+		let filters_html = me.dialog.get_field("filters_html");
+		let wrapper = filters_html.$wrapper[0];
+		let filters = ``;
 
-			if (field.fieldname == fieldname) {
-				me.fields.splice(idx, 1);
-				break;
-			}
+		for (let idx in me.filters) {
+			filters += `
+				<div class="control-input flex align-center form-control filters_order filters-sortable"
+					style="display: block; margin-bottom: 5px;" data-fieldname="${me.filters[idx].fieldname}"
+					data-doctype="${me.filters[idx].doctype}">
+					<div class="row">
+						<div class="col-md-1">
+							<i class="fa fa-bars text-muted filters-sortable-handle" aria-hidden="true"></i>
+						</div>
+						<div class="col-md-10" style="padding-left:0px;">
+							${me.filters[idx].label}
+						</div>
+						<div class="col-md-1">
+							<a class="text-muted remove-filter" data-fieldname="${me.filters[idx].fieldname}"
+								data-doctype="${me.filters[idx].doctype}">
+								<i class="fa fa-trash-o" aria-hidden="true"></i>
+							</a>
+						</div>
+					</div>
+				</div>`;
 		}
-		me.set_removed_fields(me.get_removed_listview_fields(me.fields.map(f => f.fieldname), existing_fields));
-		me.refresh();
-		me.update_fields();
+
+		filters_html.html(`
+			<div class="form-group">
+				<div class="clearfix">
+					<label class="control-label" style="padding-right: 0px;">Listview Filters</label>
+				</div>
+				<div class="filters-control-input-wrapper">
+				${filters}
+				</div>
+				<p class="help-box small text-muted hidden-xs">
+					<a class="add-new-fields text-muted">
+						+ Add / Remove Filters
+					</a>
+				</p>
+			</div>
+		`);
+
+		new Sortable(wrapper.getElementsByClassName("filters-control-input-wrapper")[0], {
+			handle: '.filters-sortable-handle',
+			draggable: '.filters-sortable',
+			onUpdate: () => {
+				me.update_filters();
+
+				// Refreshes the filters
+				me.setup_listview_filters();
+			}
+		});
+
+		// Delete filter
+		let remove_filters = filters_html.$wrapper[0].getElementsByClassName("remove-filter");
+		for (let idx = 0; idx < remove_filters.length; idx++) {
+			remove_filters.item(idx).onclick = () => me.remove_listview_filters(remove_filters.item(idx).getAttribute("data-doctype"),
+				remove_filters.item(idx).getAttribute("data-fieldname"));
+		}
+		// Filters selector
+		let reset_filters = "frappe.desk.doctype.list_view_settings.list_view_settings.get_default_listview_filters";
+		let add_new_filters = filters_html.$wrapper[0].getElementsByClassName("add-new-fields")[0];
+		add_new_filters.onclick = () => me.fields_selector("for_list_filters", true, reset_filters, me.get_active_filters_fields());
+	}
+
+	get_active_filters_fields() {
+		let me = this;
+
+		let active_fields = {};
+
+		active_fields[me.meta.name] = [];
+		me.filters.forEach(field => {
+			if (field.doctype === me.meta.name) {
+				active_fields[me.meta.name].push(field.fieldname);
+			}
+		});
+
+		frappe.meta.get_table_fields(me.doctype).map(df => {
+			active_fields[df.options] = [];
+			me.filters.forEach(field => {
+				if (field.doctype === df.options) {
+					active_fields[df.options].push(field.fieldname);
+				}
+			});
+		});
+
+		return active_fields;
+	}
+
+	remove_listview_fields(fieldname) {
+		let me = this;
+		let existing_fields = me.fields;
+
+		me.fields = [];
+		existing_fields.filter(field => {
+			if (field.fieldname !== fieldname) {
+				me.fields.push(field);
+			} else {
+				me.removed_fields.push(field);
+			}
+		});
+
+		me.dialog.set_value("fields", JSON.stringify(me.fields));
+		me.setup_listview_fields();
+	}
+
+	remove_listview_filters(doctype, fieldname) {
+		let me = this;
+		let existing_filters = me.filters;
+
+		me.filters = [];
+		existing_filters.forEach(filter => {
+			if (filter.doctype === doctype && filter.fieldname === fieldname) {
+				me.removed_filters.push(filter);
+			} else {
+				me.filters.push(filter);
+			}
+		});
+
+		me.dialog.set_value("filters", JSON.stringify(me.filters));
+		me.setup_listview_filters();
 	}
 
 	update_fields() {
 		let me = this;
 
-		let fields_html = me.dialog.get_field("fields_html");
-		let wrapper = fields_html.$wrapper[0];
-
-		let fields_order = wrapper.getElementsByClassName("fields_order");
+		let existing_fields = me.fields;
 		me.fields = [];
 
+		let wrapper = me.dialog.get_field("fields_html").$wrapper[0];
+		let fields_order = wrapper.getElementsByClassName("fields_order");
+
 		for (let idx = 0; idx < fields_order.length; idx++) {
-			me.fields.push({
-				fieldname: fields_order.item(idx).getAttribute("data-fieldname"),
-				label: fields_order.item(idx).getAttribute("data-label")
-			});
+			me.fields.push(existing_fields.find(fld =>
+				fld.fieldname === fields_order.item(idx).getAttribute("data-fieldname")));
 		}
 
 		me.dialog.set_value("fields", JSON.stringify(me.fields));
-		me.dialog.get_value("fields");
 	}
 
-	column_selector() {
+	update_filters() {
+		let me = this;
+
+		let existing_filters = me.filters;
+		me.filters = [];
+
+		let wrapper = me.dialog.get_field("filters_html").$wrapper[0];
+		let filters_order = wrapper.getElementsByClassName("filters_order");
+
+		for (let idx = 0; idx < filters_order.length; idx++) {
+			me.filters.push(existing_filters.find(flt =>
+				flt.doctype === filters_order.item(idx).getAttribute("data-doctype") &&
+				flt.fieldname === filters_order.item(idx).getAttribute("data-fieldname")));
+		}
+
+		me.dialog.set_value("filters", JSON.stringify(me.filters));
+	}
+
+	fields_selector(selector, with_table_fields, reset_cmd, active_fields) {
 		let me = this;
 
 		let d = new frappe.ui.Dialog({
-			title: __("{0} Fields", [__(me.doctype)]),
+			title: __("Fields"),
 			fields: [
 				{
 					label: __("Reset Fields"),
 					fieldtype: "Button",
 					fieldname: "reset_fields",
-					click: () => me.reset_listview_fields(d)
+					click: () => me.reset_options(d, reset_cmd)
 				},
-				{
-					label: __("Select Fields"),
-					fieldtype: "MultiCheck",
-					fieldname: "fields",
-					options: me.get_doctype_fields(me.meta, me.fields.map(f => f.fieldname)),
-					columns: 2
-				}
+				...me.get_fields(me.meta, with_table_fields, active_fields)
 			]
 		});
 		d.set_primary_action(__('Save'), () => {
-			let values = d.get_values().fields;
 
-			me.set_removed_fields(me.get_removed_listview_fields(values, me.fields.map(f => f.fieldname)));
-
-			me.fields = [];
-			me.set_subject_field(me.meta);
-			me.set_status_field();
-
-			for (let idx in values) {
-				let value = values[idx];
-
-				if (me.fields.length === parseInt(me.dialog.get_values().total_fields)) {
-					break;
-				} else if (value != me.subject_field.fieldname) {
-					let field = frappe.meta.get_docfield(me.doctype, value);
-					if (field) {
-						me.fields.push({
-							label: field.label,
-							fieldname: field.fieldname
-						});
-					}
-				}
+			if (selector === "for_list_fields") {
+				me.set_new_listview_fields(d.get_values());
+			} else if (selector === "for_list_filters") {
+				me.set_new_listview_filters(d.get_values());
 			}
 
-			me.refresh();
-			me.dialog.set_value("fields", JSON.stringify(me.fields));
 			d.hide();
 		});
+
 		d.show();
 	}
 
-	reset_listview_fields(dialog) {
+	set_new_listview_fields(values) {
 		let me = this;
 
-		frappe.xcall("frappe.desk.doctype.list_view_settings.list_view_settings.get_default_listview_fields", {
-			doctype: me.doctype
-		}).then((fields) => {
-			let field = dialog.get_field("fields");
-			field.df.options = me.get_doctype_fields(me.meta, fields);
+		values = values[me.doctype];
+		let existing_fields = me.fields;
+		me.fields = [];
+		me.set_subject_field(me.meta);
+		me.set_status_field();
+
+		for (let idx in values) {
+			let value = values[idx];
+
+			if (me.fields.length === parseInt(me.dialog.get_values().total_fields)) {
+				break;
+			} else if (value != me.subject_field.fieldname) {
+				let field = frappe.meta.get_docfield(me.doctype, value);
+				if (field) {
+					me.fields.push({
+						label: field.label,
+						fieldname: field.fieldname
+					});
+				}
+			}
+		}
+
+		me.removed_fields.concat(me.get_removed(me.fields, existing_fields));
+
+		me.setup_listview_fields();
+		me.dialog.set_value("fields", JSON.stringify(me.fields));
+	}
+
+	set_new_listview_filters(values) {
+		let me = this;
+
+		let existing_filters = me.filters;
+		me.filters = [];
+
+		Object.keys(values).forEach(doctype => {
+			frappe.model.with_doctype(doctype, () => {
+				values[doctype].forEach(field => {
+					let meta = frappe.get_meta(doctype);
+					let df = frappe.meta.get_docfield(doctype, field);
+					let label = meta.istable ? __("{0} ({1})", [df.label, doctype]) : __(df.label);
+					let options = df.options;
+					let condition = '=';
+					let fieldtype = df.fieldtype;
+
+					if (['Text', 'Small Text', 'Text Editor', 'HTML Editor', 'Data', 'Code', 'Read Only'].includes(fieldtype)) {
+						fieldtype = 'Data';
+						condition = 'like';
+					}
+
+					if (df.fieldtype == "Select" && df.options) {
+						options = df.options.split("\n");
+						if (options.length > 0 && options[0] != "") {
+							options.unshift("");
+							options = options.join("\n");
+						}
+					}
+
+					let default_value = (fieldtype === 'Link') ? frappe.defaults.get_user_default(options) : null;
+					if (['__default', '__global'].includes(default_value)) {
+						default_value = null;
+					}
+
+					me.filters.push({
+						doctype: doctype,
+						fieldtype: fieldtype,
+						label: label,
+						options: options,
+						fieldname: df.fieldname,
+						condition: condition,
+						default: default_value,
+						ignore_link_validation: fieldtype === 'Dynamic Link',
+						is_filter: 1
+					});
+				});
+			});
+		});
+
+		me.removed_filters.concat(me.get_removed(me.filters, existing_filters));
+
+		me.setup_listview_filters();
+		me.dialog.set_value("filters", JSON.stringify(me.filters));
+	}
+
+	get_fields(meta, with_table_fields, active_fields) {
+		let me = this;
+
+		let fields = [
+			{
+				label: __(meta.name),
+				fieldtype: 'MultiCheck',
+				fieldname: meta.name,
+				columns: 2,
+				options: me.get_doctype_fields(meta, active_fields[meta.name])
+			}
+		];
+
+		if (with_table_fields) {
+			frappe.meta.get_table_fields(me.doctype).map(df => {
+				let table_doctype = df.options;
+
+				frappe.model.with_doctype(table_doctype, () => {
+					let meta = frappe.get_meta(table_doctype);
+
+					fields.push({
+						label: __(meta.name),
+						fieldtype: 'MultiCheck',
+						fieldname: meta.name,
+						columns: 2,
+						options: me.get_doctype_fields(meta, active_fields[meta.name])
+					});
+				});
+			});
+		}
+
+		return fields;
+	}
+
+	get_doctype_fields(meta, fields) {
+		let multiselect_fields = [];
+
+		meta.fields.forEach(field => {
+			if (!in_list(frappe.model.no_value_type, field.fieldtype)) {
+				multiselect_fields.push({
+					label: field.label,
+					value: field.fieldname,
+					checked: in_list(fields, field.fieldname)
+				});
+			}
+		});
+
+		return multiselect_fields;
+	}
+
+	reset_options(dialog, reset_cmd) {
+		let me = this;
+
+		frappe.xcall(reset_cmd, { doctype: me.doctype }).then((fields) => {
+			Object.keys(fields).forEach(dt => {
+				frappe.model.with_doctype(dt, () => {
+					let meta = frappe.get_meta(dt);
+					let field = dialog.get_field(dt);
+
+					field.df.options = me.get_doctype_fields(meta, fields[dt]);
+				});
+			});
 			dialog.refresh();
 		});
 
 	}
 
-	get_listview_fields(meta) {
+	set_listview_fields(meta) {
 		let me = this;
 
-		if (!me.settings.fields) {
-			me.set_list_view_fields(meta);
-		} else {
-			me.fields = JSON.parse(this.settings.fields);
+		if (me.settings.fields) {
+			return;
 		}
-
-		me.fields.uniqBy(f => f.fieldname);
-	}
-
-	set_list_view_fields(meta) {
-		let me = this;
 
 		me.set_subject_field(meta);
 		me.set_status_field();
@@ -303,6 +538,25 @@ export default class ListSettings {
 				});
 			}
 		});
+	}
+
+	set_listview_filters(meta) {
+		let me = this;
+
+		if (me.settings.filters) {
+			return;
+		}
+
+		let filters = {};
+		filters[me.doctype] = [];
+
+		meta.fields.forEach(field => {
+			if (field.in_standard_filter && !in_list(frappe.model.no_value_type, field.fieldtype)) {
+				filters[me.doctype].push(field.fieldname);
+			}
+		});
+
+		me.set_new_listview_filters(filters);
 	}
 
 	set_subject_field(meta) {
@@ -337,22 +591,6 @@ export default class ListSettings {
 		}
 	}
 
-	get_doctype_fields(meta, fields) {
-		let multiselect_fields = [];
-
-		meta.fields.forEach(field => {
-			if (!in_list(frappe.model.no_value_type, field.fieldtype)) {
-				multiselect_fields.push({
-					label: field.label,
-					value: field.fieldname,
-					checked: in_list(fields, field.fieldname)
-				});
-			}
-		});
-
-		return multiselect_fields;
-	}
-
 	get_removed_listview_fields(new_fields, existing_fields) {
 		let me = this;
 		let removed_fields = [];
@@ -370,13 +608,33 @@ export default class ListSettings {
 		return removed_fields;
 	}
 
-	set_removed_fields(fields) {
+	get_removed(new_list, existing_list) {
 		let me = this;
+		let _new_list = {};
+		let removed = [];
 
-		if (me.removed_fields) {
-			me.removed_fields.concat(fields);
-		} else {
-			me.removed_fields = fields;
-		}
+		let push_to_new_list = function (doctype, fieldname) {
+			if (_new_list[doctype]) {
+				_new_list[doctype].push(fieldname);
+			} else {
+				_new_list[doctype] = [fieldname];
+			}
+		};
+
+		let add_to_removed = function (list, el) {
+			if (!list || !in_list(list, el.fieldname)) {
+				removed.push(el);
+			}
+		};
+
+		new_list.forEach(el => {
+			push_to_new_list(el.doctype ? el.doctype : me.doctype, el.fieldname);
+		});
+
+		existing_list.forEach(el => {
+			add_to_removed(el.doctype ? _new_list[el.doctype] : _new_list[me.doctype], el);
+		});
+
+		return removed;
 	}
 }

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -234,10 +234,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	}
 
-	refresh_columns(meta, list_view_settings) {
+	refresh_fields(meta, list_view_settings) {
 		this.meta = meta;
 		this.list_view_settings = list_view_settings;
 
+		this.filter_area.setup(true);
 		this.setup_columns();
 		this.refresh(true);
 	}
@@ -1297,7 +1298,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		if (frappe.user.has_role('System Manager')) {
 			items.push({
-				label: __('Settings'),
+				label: __('List Settings'),
 				action: () => this.show_list_settings(),
 				standard: true
 			});


### PR DESCRIPTION
-After this PR has been merged, users would be able to add Child Table fields in Listview standard filters.
-This can be done by going into Settings and then customizing the filters.

ref: https://app.asana.com/0/1198992588740629/1198992588740640

![child_table_filter](https://user-images.githubusercontent.com/56826544/98506119-d636b580-2280-11eb-9fe6-87c6a5e758d7.gif)
