### PR TITLE
fix: Removes chart.js from build

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -221,7 +221,6 @@
 		"public/js/frappe/chat.js",
 		"public/js/frappe/social/social_factory.js",
 		"public/js/frappe/utils/energy_point_utils.js",
-		"public/js/frappe/ui/chart.js",
 		"public/js/frappe/barcode_scanner/index.js"
 	],
 	"css/module.min.css": [


### PR DESCRIPTION
frappe js build errors during frappe.chart import which was removed previously. This PR removes chat.js from build.json