### PR TITLE
chore: add check to ignore adding owner links

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -25,6 +25,7 @@
   "disabled",
   "linked_with",
   "is_your_company_address",
+  "ignore_owner_links",
   "links"
  ],
  "fields": [
@@ -149,12 +150,18 @@
    "fieldtype": "Table",
    "label": "Links",
    "options": "Dynamic Link"
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_owner_links",
+   "fieldtype": "Check",
+   "label": "Ignore Owner Links"
   }
  ],
  "icon": "fa fa-map-marker",
  "idx": 5,
- "modified": "2019-09-08 11:41:04.145589",
- "modified_by": "Administrator",
+ "modified": "2020-11-27 03:34:40.212734",
+ "modified_by": "himanshu@bloomstack.com",
  "module": "Contacts",
  "name": "Address",
  "name_case": "Title Case",

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -45,7 +45,7 @@ class Address(Document):
 
 	def link_address(self):
 		"""Link address based on owner"""
-		if not self.links and not self.is_your_company_address:
+		if not self.links and not self.is_your_company_address and not self.ignore_owner_links:
 			contact_name = frappe.db.get_value("Contact", {"email_id": self.owner})
 			if contact_name:
 				contact = frappe.get_cached_doc('Contact', contact_name)


### PR DESCRIPTION
- While adding address, the system links all the entries in Contact's Dynamic Link Table, which in somecases is not the desired functionality