### PR TITLE
fix: use 'cstr' instead of 'String'

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -86,7 +86,7 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			var f = this.fields_dict[key];
 			if(f.get_value) {
 				var v = f.get_value();
-				if(f.df.reqd && is_null(strip_html(String(v))))
+				if(f.df.reqd && is_null(strip_html(cstr(v))))
 					errors.push(__(f.df.label));
 
 				if(!is_null(v)) ret[f.df.fieldname] = v;


### PR DESCRIPTION
String will cause issues with `undefined` variables.

![image](https://user-images.githubusercontent.com/37302950/103196981-2c33eb00-490b-11eb-8da5-bc93be70a41a.png)
