### PR TITLE
fix: use 'endfor' for ending the loop

### DIFF
--- a/frappe/core/doctype/version/version_view.html
+++ b/frappe/core/doctype/version/version_view.html
@@ -21,7 +21,7 @@
 			<td class="danger">{{ item[1] }}</td>
 			<td class="success">{{ item[2] }}</td>
 		</tr>
-		{% endif %}
+		{% endfor %}
 	</tbody>
 </table>
 {% endif %}
@@ -58,7 +58,7 @@
 					</table>
 				</td>
 			</tr>
-			{% endif %}
+			{% endfor %}
 		</tbody>
 	</table>
 


### PR DESCRIPTION
`endif` was used instead of `endfor` for ending the loops