### PR TITLE
fix: Fixes issue where if Link label isn't set blur event triggers da…

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -86,6 +86,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			return;
 		}
 		this.$input.val(__(link_display));
+		this.label = __(link_display);
 		this.data_value = value;
 	},
 	parse_validate_and_set_in_model: function(value, label, e) {


### PR DESCRIPTION
Fixes:
- Adds missing label set on Link Controls. This caused item_code (in erpnext) to trigger fetching image and description for an item that had not changed after a blur event. See line: 314 of this file