### PR TITLE
fix: pass txt from multiselect pills for filtering

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_pills.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_pills.js
@@ -129,7 +129,8 @@ frappe.ui.form.ControlMultiSelectPills = frappe.ui.form.ControlAutocomplete.exte
 	get_data() {
 		let data;
 		if(this.df.get_data) {
-			data = this.df.get_data();
+			let txt = this.$input.val();
+			data = this.df.get_data(txt);
 			if (data && data.then) {
 				data.then((r) => {
 					this.set_data(r);


### PR DESCRIPTION
- [Asana](https://app.asana.com/0/1192118403864545/1199709846089490)
- `txt` wasn't being passed to `get_data` function which breaks the filtering for `multiselect_pills`