### PR TITLE
fix: Clear fetch from values on removal of link flied data

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -546,12 +546,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			});
 		} else {
 			me.reset_value();
+			me.set_fetch_values(df, docname, value);
 		}
 	},
-	set_fetch_values: function(df, docname, fetch_values) {
-		var fl = this.frm.fetch_dict[df.fieldname].fields;
-		for(var i=0; i < fl.length; i++) {
-			frappe.model.set_value(df.parent, docname, fl[i], fetch_values[i], df.fieldtype);
+	set_fetch_values: function (df, docname, fetch_values) {
+		let field_list = this.frm.fetch_dict[df.fieldname] && this.frm.fetch_dict[df.fieldname].fields;
+		for (let i in field_list) {
+			frappe.model.set_value(df.parent, docname, field_list[i], fetch_values ? fetch_values[i] : fetch_values, df.fieldtype);
 		}
 	}
 });


### PR DESCRIPTION
[TASK](https://app.asana.com/0/1192407897953440/1199874277921246/f)

The code Is capable for removing the Fetch From Dependent fields value if the actual Link Values is set to Null.
(It May not Work in case of Custom Logic written for any Particular field. ex: "Item Name" under "Sales Order Items")
![fetch_from_dependent_fields](https://user-images.githubusercontent.com/58166671/107030711-07b71280-67d7-11eb-9c60-5dc1650f4621.gif)
