### PR TITLE
fix: use shadow dom to render email content in timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -303,6 +303,12 @@ frappe.ui.form.Timeline = class Timeline {
 				return false;
 			});
 
+		let el = $timeline_item.find(".timeline-item-content-html");
+
+		if (el && el.length && el[0]) {
+			let shadow = el[0].attachShadow({mode: 'open'});
+			shadow.innerHTML = c.content_html;
+		}
 
 		if(c.communication_type=="Communication" && c.communication_medium==="Email") {
 			this.last_type = c.communication_medium;

--- a/frappe/public/js/frappe/form/templates/timeline_item.html
+++ b/frappe/public/js/frappe/form/templates/timeline_item.html
@@ -129,7 +129,9 @@
 						<hr>
 					{% endif %}
 
-					{%= data.content_html %}
+					<div class="timeline-item-content-html">
+
+					</div>
 				</div>
 				<div class="timeline-item-edit"></div>
 				{% if(data.attachments && data.attachments.length) { %}


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1192118403864545/1199906949156523)

- Frappe appends email css in DOM due to which frappe's elements get styled by email css
- Added Shadow DOM to prevent this