### PR TITLE
fix: parse json if string

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -120,7 +120,6 @@ def get_percentage_difference(doc, filters, result):
 def calculate_previous_result(doc, filters):
 	from frappe.utils import add_to_date
 
-	print(doc, filters)
 	current_date = frappe.utils.now()
 	if doc.stats_time_interval == 'Daily':
 		previous_date = add_to_date(current_date, days=-1)

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -9,6 +9,7 @@ from frappe.utils import cint
 from frappe.model.naming import append_number_if_name_exists
 from frappe.modules.export_file import export_to_files
 from frappe.utils.safe_exec import safe_exec
+from six import string_types
 
 class NumberCard(Document):
 	def autoname(self):
@@ -58,7 +59,7 @@ def has_permission(doc, ptype, user):
 
 @frappe.whitelist()
 def get_result(doc, filters, to_date=None):
-	number_card = frappe._dict(frappe.parse_json(doc))
+	number_card = frappe._dict(frappe.parse_json(doc)) if isinstance(doc, string_types) else doc
 
 	# For Servcer Script Enabled Number Cards
 	if number_card.type == "Script" and number_card.script:
@@ -119,6 +120,7 @@ def get_percentage_difference(doc, filters, result):
 def calculate_previous_result(doc, filters):
 	from frappe.utils import add_to_date
 
+	print(doc, filters)
 	current_date = frappe.utils.now()
 	if doc.stats_time_interval == 'Daily':
 		previous_date = add_to_date(current_date, days=-1)


### PR DESCRIPTION
- parse doc to json if incoming parameter is a string
```
Traceback (most recent call last):
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/__init__.py", line 1055, in call
    return fn(*args, **newargs)
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/desk/doctype/number_card/number_card.py", line 113, in get_percentage_difference
    previous_result = calculate_previous_result(doc, filters)
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/desk/doctype/number_card/number_card.py", line 133, in calculate_previous_result
    number = get_result(doc, filters, previous_date)
  File "/home/himanshu/Workspace/bloomstack/apps/frappe/frappe/desk/doctype/number_card/number_card.py", line 61, in get_result
    number_card = frappe._dict(frappe.parse_json(doc))
TypeError: 'NumberCard' object is not iterable
```