### PR TITLE
fix: run ifno condition for secondary action in frappe.confirm

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -32,18 +32,15 @@ frappe.confirm = function(message, ifyes, ifno) {
 		],
 		primary_action_label: __("Yes"),
 		primary_action: function() {
-			if(ifyes)
-			{
-				ifyes();
-				d.hide();
-			} 
-			else
-			{
-				ifno();
-				d.hide();
-			}
+			if(ifyes) ifyes();
+			d.hide();
+
 		},
-		secondary_action_label: __("No")
+		secondary_action_label: __("No"),
+		secondary_action: function() {
+			if(ifno) ifno();
+			d.hide();
+		}
 	});
 	d.show();
 

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -32,8 +32,16 @@ frappe.confirm = function(message, ifyes, ifno) {
 		],
 		primary_action_label: __("Yes"),
 		primary_action: function() {
-			if(ifyes) ifyes();
-			d.hide();
+			if(ifyes)
+			{
+				ifyes();
+				d.hide();
+			} 
+			else
+			{
+				ifno();
+				d.hide();
+			}
 		},
 		secondary_action_label: __("No")
 	});
@@ -42,14 +50,6 @@ frappe.confirm = function(message, ifyes, ifno) {
 	// flag, used to bind "okay" on enter
 	d.confirm_dialog = true;
 
-	// no if closed without primary action
-	if(ifno) {
-		d.onhide = function() {
-			if(!d.primary_action_fulfilled) {
-				ifno();
-			}
-		};
-	}
 	return d;
 }
 


### PR DESCRIPTION
- When frappe.confirm is being closed, it triggers `ifno` function assigned.
- Frappe.confirm should only run `ifno` only if the user clicks on the Secondary Action

https://user-images.githubusercontent.com/80836439/118592406-83a3fc00-b7c3-11eb-81e2-65b9eb0fc0fa.mp4



