### PR TITLE
fix: optimize yearly filter

### DIFF
--- a/frappe/config/desktop.py
+++ b/frappe/config/desktop.py
@@ -119,16 +119,5 @@ def get_data():
 			"color": '#FF4136',
 			'standard': 1,
 			'idx': 10
-		},
-		{
-			"module_name": 'Insights',
-			"category": "Places",
-			"label": _('Insight Engine'),
-			"icon": "octicon octicon-graph",
-			"type": "link",
-			"link": "#insight-engine",
-			"color": '#FF4136',
-			'standard': 1,
-			'idx': 10
-		},
+		}
 	]

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -90,6 +90,7 @@ def update_global_settings(args):
 
 def run_post_setup_complete(args):
 	disable_future_access()
+	sync_dashboards()
 	frappe.db.commit()
 	frappe.clear_cache()
 
@@ -239,6 +240,10 @@ def disable_future_access():
 		page.flags.do_not_update_json = True
 		page.flags.ignore_permissions = True
 		page.save()
+
+def sync_dashboards():
+	from frappe.utils.dashboard import sync_dashboards
+	sync_dashboards()
 
 @frappe.whitelist()
 def load_messages(language):

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -16,6 +16,7 @@ from frappe.website import render
 from frappe.core.doctype.language.language import sync_languages
 from frappe.modules.utils import sync_customizations
 from frappe.utils import global_search
+from frappe.utils.dashboard import sync_dashboards
 
 def migrate(verbose=True, rebuild_website=False, skip_failing=False):
 	'''Migrate all apps to the latest version, will:
@@ -23,6 +24,7 @@ def migrate(verbose=True, rebuild_website=False, skip_failing=False):
 	- run patches
 	- sync doctypes (schema)
 	- sync fixtures
+	- sync dashboards
 	- sync desktop icons
 	- sync web pages (from /www)
 	- sync web pages (from /www)
@@ -50,6 +52,7 @@ def migrate(verbose=True, rebuild_website=False, skip_failing=False):
 		frappe.model.sync.sync_all(verbose=verbose)
 		frappe.translate.clear_cache()
 		sync_fixtures()
+		sync_dashboards()
 		sync_customizations()
 		sync_languages()
 

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -85,6 +85,7 @@ def sync_dashboards(app=None):
 	"""Import, overwrite fixtures from `[app]/fixtures`."""
 	if not cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
 		return
+
 	if app:
 		apps = [app]
 	else:
@@ -98,7 +99,7 @@ def sync_dashboards(app=None):
 			frappe.flags.in_import = False
 
 def make_records_in_module(app, module):
-	dashboards_path = frappe.get_module_path(module, "{module}_dashboard".format(module=module))
+	dashboards_path = frappe.get_module_path(module, "dashboard")
 	charts_path = frappe.get_module_path(module, "dashboard chart")
 	cards_path = frappe.get_module_path(module, "number card")
 

--- a/frappe/utils/dateutils.py
+++ b/frappe/utils/dateutils.py
@@ -89,6 +89,8 @@ def get_dates_from_timegrain(from_date, to_date, timegrain="Daily"):
 		months = 1
 	elif "Quarterly" == timegrain:
 		months = 3
+	elif "Yearly" == timegrain:
+		years = 1
 
 	if "Weekly" == timegrain:
 		dates = [get_last_day_of_week(from_date)]


### PR DESCRIPTION
- Sync dashboards when site is installed and during migrations.
- Remove insight engine page link in desktop.