### PR TITLE
fix: cache dashboard result and fix number card percentage display

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -261,7 +261,7 @@ export default class NumberCardWidget extends Widget {
 			$(this.body).find('.widget-content').append(`<div class="card-stats ${color_class}">
 				<span class="percentage-stat">
 					${caret_html}
-					${Math.abs(this.percentage_stat)} %
+					${frappe.utils.shorten_number(Math.abs(this.percentage_stat))} %
 				</span>
 				<span class="stat-period text-muted">
 					${stats_qualifier}
@@ -277,7 +277,7 @@ export default class NumberCardWidget extends Widget {
 			result: this.number
 		}).then(res => {
 			if (res !== undefined) {
-				this.percentage_stat = frappe.utils.shorten_number(res);
+				this.percentage_stat = res;
 			}
 		});
 	}

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -8,7 +8,7 @@ from frappe.utils import cint, get_link_to_form
 from frappe.modules.import_file import import_file_by_path
 import os
 from os.path import join
-
+import json
 
 def cache_source(function):
 	@wraps(function)
@@ -20,8 +20,8 @@ def cache_source(function):
 		no_cache = kwargs.get("no_cache")
 		if no_cache:
 			return function(chart = chart, no_cache = no_cache)
-		chart_name = frappe.parse_json(chart).name
-		cache_key = "chart-data:{}".format(chart_name)
+
+		cache_key = frappe.parse_json(chart).name
 		if int(kwargs.get("refresh") or 0):
 			results = generate_and_cache_results(kwargs, function, cache_key, chart)
 		else:
@@ -59,6 +59,7 @@ def generate_and_cache_results(args, function, cache_key, chart):
 			raise
 
 	frappe.db.set_value("Dashboard Chart", args.chart_name, "last_synced_on", frappe.utils.now(), update_modified = False)
+	frappe.cache().set_value(cache_key, results)
 	return results
 
 def get_dashboards_with_link(docname, doctype):

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -8,7 +8,6 @@ from frappe.utils import cint, get_link_to_form
 from frappe.modules.import_file import import_file_by_path
 import os
 from os.path import join
-import json
 
 def cache_source(function):
 	@wraps(function)


### PR DESCRIPTION
- Add caching for dashboard chart based on the name of dashboard chart document.
- `shorten_number` after computing the absolute value for number card percentage difference