### PR TITLE
fix: show timeframe in chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -194,7 +194,7 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 	chart_config = {
 		"labels": [get_period(r[0], timegrain) for r in result],
 		"datasets": [{
-			"name": chart.name,
+			"name": "{0} - {1}".format(getdate(from_date), getdate(to_date)),
 			"values": [r[1] for r in result]
 		}]
 	}
@@ -204,7 +204,7 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 			to_date, filters, date_filters)
 
 		chart_config["datasets"].append({
-			"name": "Previous " + chart.name,
+			"name": "{0} - {1}".format(getdate(from_date), getdate(to_date)),
 			"values": [r[1] for r in previous_result]
 		})
 


### PR DESCRIPTION
- ![image](https://user-images.githubusercontent.com/7310479/123919340-7a9d7180-d9a2-11eb-8f18-ea18411cfcaa.png)
- ![image](https://user-images.githubusercontent.com/7310479/123735344-a9411c80-d8bc-11eb-90bc-a8702d2a7991.png)
- Show from and to date in the dashboard chart instead of name
