### PR TITLE
fix: removed help label code from form_sidebar file

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -48,9 +48,6 @@
 			<span class="badge n-comments">0</span>
 		</a>
 	</li>
-    {% if(frappe.help.has_help(doctype)) { %}
-    <li><a class="help-link list-link" data-doctype="{{ doctype }}">{{ __("Help") }}</a></li>
-    {% } %}
 </ul>
 <ul class="list-unstyled sidebar-menu form-assignments">
 	<li class="h6 assigned-to-label">{%= __("Assigned To") %}</li>


### PR DESCRIPTION
**Task Link**: https://app.asana.com/0/1194051119161697/1200464637755574/f

**Description:** Removed help button related code from form_sidebar.html file