### PR TITLE
feat: OR filters in dashboard chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -36,6 +36,8 @@
   "script",
   "filters_section",
   "filters_json",
+  "or_filters_section",
+  "or_filters_json",
   "dynamic_filters_section",
   "dynamic_filters_json",
   "chart_options_section",
@@ -116,7 +118,7 @@
   {
    "fieldname": "filters_section",
    "fieldtype": "Section Break",
-   "label": "Filters"
+   "label": "AND Filters Section"
   },
   {
    "fieldname": "filters_json",
@@ -284,9 +286,20 @@
    "fieldname": "show_previous_data",
    "fieldtype": "Check",
    "label": "Show Corresponding Previous Years Data"
+  },
+  {
+   "fieldname": "or_filters_json",
+   "fieldtype": "Code",
+   "label": "OR Filters JSON",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "or_filters_section",
+   "fieldtype": "Section Break",
+   "label": "OR Filters Section"
   }
  ],
- "modified": "2021-06-26 16:50:48.603163",
+ "modified": "2021-07-04 23:21:32.844514",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -7,6 +7,7 @@ frappe.ui.form.on('Number Card', {
 			frm.disable_form();
 		}
 		frm.set_df_property("filters_section", "hidden", 1);
+		frm.set_df_property("or_filters_section", "hidden", 1);
 		frm.set_df_property("dynamic_filters_section", "hidden", 1);
 		frm.trigger('set_options');
 
@@ -223,6 +224,11 @@ frappe.ui.form.on('Number Card', {
 	},
 
 	render_filters_table: function(frm) {
+		frm.trigger("render_and_filters_table");
+		frm.trigger("render_or_filters_table");
+	},
+
+	render_and_filters_table: function(frm) {
 		frm.set_df_property("filters_section", "hidden", 0);
 		let is_document_type = frm.doc.type == 'Document Type';
 		let is_dynamic_filter = f => ['Date', 'DateRange'].includes(f.fieldtype) && f.default;
@@ -296,13 +302,13 @@ frappe.ui.form.on('Number Card', {
 
 		if (!filters_set) {
 			const filter_row = $(`<tr><td colspan="3" class="text-muted text-center">
-				${__("Click to Set Filters")}</td></tr>`);
+				${__("Click to Set AND Filters")}</td></tr>`);
 			table.find('tbody').append(filter_row);
 		}
 
 		table.on('click', () => {
 			let dialog = new frappe.ui.Dialog({
-				title: __('Set Filters'),
+				title: __('Set AND Filters'),
 				fields: fields.filter(f => !is_dynamic_filter(f)),
 				primary_action: function() {
 					let values = this.get_values();
@@ -339,6 +345,92 @@ frappe.ui.form.on('Number Card', {
 						&& frappe.query_reports[frm.doc.report_name].onload(frappe.query_report);
 			}
 
+			dialog.set_values(filters);
+		});
+
+	},
+
+	render_or_filters_table: function(frm) {
+		frm.set_df_property("or_filters_section", "hidden", 0);
+		let is_document_type = frm.doc.type == 'Document Type';
+		let is_dynamic_filter = f => ['Date', 'DateRange'].includes(f.fieldtype) && f.default;
+
+		let wrapper = $(frm.get_field('or_filters_json').wrapper).empty();
+		let table = $(`<table class="table table-bordered" style="cursor:pointer; margin:0px;">
+			<thead>
+				<tr>
+					<th style="width: 20%">${__('Filter')}</th>
+					<th style="width: 20%">${__('Condition')}</th>
+					<th>${__('Value')}</th>
+				</tr>
+			</thead>
+			<tbody></tbody>
+		</table>`).appendTo(wrapper);
+		$(`<p class="text-muted small">${__("Click table to edit")}</p>`).appendTo(wrapper);
+
+		let filters = JSON.parse(frm.doc.or_filters_json || '[]');
+		let filters_set = false;
+		let fields = [];
+
+		if (is_document_type) {
+			fields = [
+				{
+					fieldtype: 'HTML',
+					fieldname: 'filter_area',
+				}
+			];
+
+			if (filters.length) {
+				filters.forEach(filter => {
+					const filter_row =
+						$(`<tr>
+							<td>${filter[1]}</td>
+							<td>${filter[2] || ""}</td>
+							<td>${filter[3]}</td>
+						</tr>`);
+
+					table.find('tbody').append(filter_row);
+				});
+				filters_set = true;
+			}
+		}
+
+		if (!filters_set) {
+			const filter_row = $(`<tr><td colspan="3" class="text-muted text-center">
+				${__("Click to Set OR Filters")}</td></tr>`);
+			table.find('tbody').append(filter_row);
+		}
+
+		table.on('click', () => {
+			let dialog = new frappe.ui.Dialog({
+				title: __('Set OR Filters'),
+				fields: fields.filter(f => !is_dynamic_filter(f)),
+				primary_action: function() {
+					let values = this.get_values();
+					if (values) {
+						this.hide();
+						if (is_document_type) {
+							let filters = frm.or_filter_group.get_filters();
+							frm.set_value('or_filters_json', JSON.stringify(filters));
+						} else {
+							frm.set_value('or_filters_json', JSON.stringify(values));
+						}
+						frm.trigger('render_filters_table');
+					}
+				},
+				primary_action_label: "Set"
+			});
+
+			if (is_document_type) {
+				frm.or_filter_group = new frappe.ui.FilterGroup({
+					parent: dialog.get_field('filter_area').$wrapper,
+					doctype: frm.doc.document_type,
+					on_change: () => {},
+				});
+				filters && frm.or_filter_group.add_filters_to_filter_group(filters);
+			}
+
+			dialog.show();
 			dialog.set_values(filters);
 		});
 

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -9,15 +9,15 @@
   "module",
   "label",
   "type",
+  "document_type",
+  "column_break_2",
+  "is_public",
   "report_name",
+  "report_field",
+  "report_function",
   "method",
   "function",
   "aggregate_function_based_on",
-  "column_break_2",
-  "document_type",
-  "report_field",
-  "report_function",
-  "is_public",
   "script_section",
   "script",
   "custom_configuration_section",
@@ -27,6 +27,8 @@
   "stats_time_interval",
   "filters_section",
   "filters_json",
+  "or_filters_section",
+  "or_filters_json",
   "dynamic_filters_section",
   "dynamic_filters_json",
   "section_break_16",
@@ -79,7 +81,7 @@
   {
    "fieldname": "filters_section",
    "fieldtype": "Section Break",
-   "label": "Filters Section"
+   "label": "AND Filters Section"
   },
   {
    "default": "0",
@@ -191,9 +193,20 @@
    "fieldname": "script",
    "fieldtype": "Code",
    "label": "Script"
+  },
+  {
+   "fieldname": "or_filters_json",
+   "fieldtype": "Code",
+   "label": "OR Filters JSON",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "or_filters_section",
+   "fieldtype": "Section Break",
+   "label": "OR Filters Section"
   }
  ],
- "modified": "2021-03-17 02:49:08.024214",
+ "modified": "2021-07-05 03:20:14.710865",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/public/js/frappe/ui/dashboard_chart.js
+++ b/frappe/public/js/frappe/ui/dashboard_chart.js
@@ -385,6 +385,7 @@ frappe.ui.DashboardChart = class DashboardChart {
 
 	prepare_chart_object() {
 		this.filters = this.filters || JSON.parse(this.chart_doc.filters_json || '[]');
+		this.or_filters = this.or_filters || JSON.parse(this.chart_doc.or_filters_json || '[]');
 	}
 
 	get_settings() {

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -201,6 +201,10 @@ frappe.dashboard_utils = {
 		return filters;
 	},
 
+	get_or_filters(doc) {
+		return JSON.parse(doc.or_filters_json || "null") || {};
+	},
+
 	get_dashboard_link_field() {
 		let field = {
 			label: __('Select Dashboard'),

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -106,11 +106,13 @@ export default class NumberCardWidget extends Widget {
 
 	get_settings(type) {
 		this.filters = this.get_filters();
+		this.or_filters = this.get_or_filters();
 		const settings_map = {
 			'Custom': {
 				method: this.card_doc.method,
 				args: {
-					filters: this.filters
+					filters: this.filters,
+					or_filters: this.or_filters
 				},
 				get_number: res => this.get_number_for_custom_card(res),
 			},
@@ -128,6 +130,7 @@ export default class NumberCardWidget extends Widget {
 				args: {
 					doc: this.card_doc,
 					filters: this.filters,
+					or_filters: this.or_filters
 				},
 				get_number: res => this.get_number_for_doctype_card(res),
 			},
@@ -136,6 +139,7 @@ export default class NumberCardWidget extends Widget {
 				args: {
 					doc: this.card_doc,
 					filters: this.filters,
+					or_filters: this.or_filters
 				},
 				get_number: res => this.get_number_for_doctype_card(res),
 			}
@@ -146,6 +150,10 @@ export default class NumberCardWidget extends Widget {
 	get_filters() {
 		const filters = frappe.dashboard_utils.get_all_filters(this.card_doc);
 		return filters;
+	}
+
+	get_or_filters() {
+		return frappe.dashboard_utils.get_or_filters(this.card_doc);
 	}
 
 	render_card() {
@@ -274,6 +282,7 @@ export default class NumberCardWidget extends Widget {
 		return frappe.xcall('frappe.desk.doctype.number_card.number_card.get_percentage_difference', {
 			doc: this.card_doc,
 			filters: this.filters,
+			or_filters: this.or_filters,
 			result: this.number
 		}).then(res => {
 			if (res !== undefined) {


### PR DESCRIPTION
- In the current version of Dashboards, its difficult to apply OR filters.
    - eg: `status is Open OR status is Complete`
- Due to this limitations, it was difficult to build dashboards where we needed OR functionality.
- Now, we can add the OR filters in the OR section.
- ![image](https://user-images.githubusercontent.com/7310479/124584972-75449900-de72-11eb-975f-d5223b3d661f.png)
- ![image](https://user-images.githubusercontent.com/7310479/124585285-c2c10600-de72-11eb-8612-9d6bb46400c4.png)
- ![image](https://user-images.githubusercontent.com/7310479/124585691-2ea36e80-de73-11eb-8335-89e512e011c6.png)