### PR TITLE
fix: encode uri while searching container

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -338,11 +338,16 @@ frappe.views.BaseList = class BaseList {
 			: [];
 	}
 
+	get_or_filters_for_args() {
+		return [];
+	}
+
 	get_args() {
 		return {
 			doctype: this.doctype,
 			fields: this.get_fields(),
 			filters: this.get_filters_for_args(),
+			or_filters: this.get_or_filters_for_args(),
 			order_by: this.sort_selector.get_sql_string(),
 			start: this.start,
 			page_length: this.page_length,


### PR DESCRIPTION
- Since the name attached to container was encoded, while searching using js, if the name was not URIencoded, no row was found.
- When we search the container using URIencoded name, the row object can be extracted in js.
- Added orfilters to baselist to enable better search parameters