### PR TITLE
hotfix: moves docperm clear cache to background job

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1007,8 +1007,7 @@ def validate_permissions_for_doctype(doctype, for_remove=False):
 	for perm in doctype.get("permissions"):
 		perm.db_update()
 
-	clear_permissions_cache(doctype.name)
-
+	frappe.enqueue("frappe.core.doctype.doctype.doctype.clear_permissions_cache", doctype=doctype.name)
 
 def clear_permissions_cache(doctype):
 	frappe.clear_cache(doctype=doctype)


### PR DESCRIPTION
Changes:
- Moves permission cache clear to a background process to ease permission manager delays

NOTE: permissions manager doesn't use any returned values from the backend. As long as no errors occur it updates its browser local copy with the sent values. So it is safe to queue permissions cache clear on the backend.