### PR TITLE
fix(file_attachment_rollover): add prev_doc in open_mapped_doc

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -44,6 +44,8 @@ frappe.ui.form.Attachments = Class.extend({
 				} else {
 					me.parent.find(".attachments-label").hide();
 				}
+			} else {
+				me.parent.find(".attachments-label").hide();
 			}
 		}
 		this.parent.toggle(true);
@@ -68,7 +70,7 @@ frappe.ui.form.Attachments = Class.extend({
 			&& docinfo["__rollover_attachments"].fileid.length !== 0 ? true : false;
 	},
 	get_attachments: function() {
-		return this.frm.get_docinfo().attachments;
+		return (this.frm.get_docinfo() && this.frm.get_docinfo().attachments) ? this.frm.get_docinfo().attachments : [];
 	},
 	add_attachment: function(attachment) {
 		let roll_over_atttachments = this.frm.doc.__islocal ?

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -78,7 +78,7 @@ frappe.ui.form.Sidebar = Class.extend({
 		this.frm.reviews && this.frm.reviews.refresh();
 		this.frm.tags && this.frm.tags.refresh(this.frm.get_docinfo().tags);
 		this.refresh_like();
-		this.frm.sidebar.refresh_comments();
+		this.frm.sidebar.sidebar.find(".comments-section").toggle(false);
 		this.image_section.toggle(!this.frm.doc.__islocal);
 		if (!this.frm.doc.__islocal) {
 			this.sidebar.find(".modified-by").html(__("{0} edited this {1}",
@@ -115,10 +115,6 @@ frappe.ui.form.Sidebar = Class.extend({
 	},
 
 	refresh_comments: function() {
-		if (this.frm.doc.__islocal) {
-			this.frm.sidebar.sidebar.find(".comments-section").toggle(false);
-			return;
-		}
 		this.frm.sidebar.sidebar.find(".comments-section").toggle(true);
 		$.map(this.frm.timeline.get_communications(), function(c) {
 			return (c.communication_type==="Communication" || (c.communication_type=="Comment" && c.comment_type==="Comment")) ? c : null;

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -313,6 +313,7 @@ $.extend(frappe.model, {
 					if(opts.run_link_triggers) {
 						frappe.get_doc(r.message.doctype, r.message.name).__run_link_triggers = true;
 					}
+					frappe.get_doc(r.message.doctype, r.message.name).prev_doc = {"prev_docname": opts.frm.doc.name, "prev_doctype": opts.frm.doc.doctype};
 					frappe.set_route("Form", r.message.doctype, r.message.name);
 				}
 			}


### PR DESCRIPTION
[Asana Link](https://app.asana.com/0/1192403191428092/1200166130781166/f)

Fixes:
- Doctype Dashboards where open_mapped_doc was used.
- remove refresh_comments from attachment's refresh.
- add validation in get_attachments to check if docinfo is present.