### PR TITLE
fix: attach file/image to unsaved document

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -165,6 +165,9 @@ export default {
 		},
 		upload_notes: {
 			default: null // "Images or video, upto 2MB"
+		},
+		__islocal: {
+			default: false
 		}
 	},
 	components: {
@@ -287,7 +290,7 @@ export default {
 			if (this.show_web_link) {
 				return this.upload_via_web_link();
 			}
-			if (this.as_dataurl) {
+			if (this.as_dataurl || this.__islocal) {
 				return this.return_as_dataurl();
 			}
 			return frappe.run_serially(

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -15,6 +15,7 @@ export default class FileUploader {
 		allow_multiple,
 		as_dataurl,
 		disable_file_browser,
+		__islocal
 	} = {}) {
 		if (!wrapper) {
 			this.make_dialog();
@@ -38,6 +39,7 @@ export default class FileUploader {
 					allow_multiple,
 					as_dataurl,
 					disable_file_browser,
+					__islocal
 				}
 			})
 		});

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -127,7 +127,7 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 
 	clear_temp_attachment(attachment) {
 		if (!this.frm.doc.__unsaved_attachments) {
-			this.frm.doc.__unsaved_attachments = []
+			this.frm.doc.__unsaved_attachments = [];
 		}
 
 		this.frm.doc.__unsaved_attachments = this.frm.doc.__unsaved_attachments.filter(

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -34,6 +34,7 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 			me.refresh();
 			me.frm.attachments.remove_attachment_by_filename(me.value, function() {
 				me.parse_validate_and_set_in_model(null);
+				me.clear_temp_attachment(me.value);
 				me.refresh();
 				me.frm.doc.docstatus == 1 ? me.frm.save('Update') : me.frm.save();
 			});
@@ -57,13 +58,15 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 	set_upload_options() {
 		let options = {
 			allow_multiple: false,
+			__islocal: this.frm.is_new(),
 			on_success: file => {
 				this.on_upload_complete(file);
 				this.toggle_reload_button();
+				this.frm.is_new() && this.save_temp_attachment(file);
 			}
 		};
 
-		if (this.frm) {
+		if (this.frm && !this.frm.is_new()) {
 			options.doctype = this.frm.doctype;
 			options.docname = this.frm.docname;
 		}
@@ -97,16 +100,38 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 	},
 
 	on_upload_complete: function(attachment) {
-		if(this.frm) {
-			this.parse_validate_and_set_in_model(attachment.file_url);
-			this.frm.attachments.update_attachment(attachment);
+		if (this.frm) {
+			this.parse_validate_and_set_in_model(attachment.file_url || attachment.name, attachment.dataurl);
+			!this.frm.is_new() && this.frm.attachments.update_attachment(attachment);
 			this.frm.doc.docstatus == 1 ? this.frm.save('Update') : this.frm.save();
 		}
-		this.set_value(attachment.file_url);
+		this.set_value(attachment.file_url || attachment.name);
 	},
 
 	toggle_reload_button() {
 		this.$value.find('[data-action="reload_attachment"]')
 			.toggle(this.file_uploader && this.file_uploader.uploader.files.length > 0);
+	},
+
+	save_temp_attachment(attachment) {
+		if (!this.frm.doc.__unsaved_attachments) {
+			this.frm.doc.__unsaved_attachments = []
+		}
+
+		this.frm.doc.__unsaved_attachments.push({
+			"fieldname": this.df.fieldname,
+			"filename": attachment.name,
+			"attachment": attachment
+		});
+	},
+
+	clear_temp_attachment(attachment) {
+		if (!this.frm.doc.__unsaved_attachments) {
+			this.frm.doc.__unsaved_attachments = []
+		}
+
+		this.frm.doc.__unsaved_attachments = this.frm.doc.__unsaved_attachments.filter(
+			__unsaved_attachment => __unsaved_attachment.filename !== attachment
+		);
 	}
 });

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -115,7 +115,7 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 
 	save_temp_attachment(attachment) {
 		if (!this.frm.doc.__unsaved_attachments) {
-			this.frm.doc.__unsaved_attachments = []
+			this.frm.doc.__unsaved_attachments = [];
 		}
 
 		this.frm.doc.__unsaved_attachments.push({


### PR DESCRIPTION
- [Asana](https://app.asana.com/0/1192118403864545/1199908440007463)
- When attaching files/images to `Attach/Attach Image`, framework tries to upload the file to server. While doing so, the file gets attached to a temperory document for eg: doctype=Job Applicant and name=New Job Applicant 1.
- Due to this the file remains an orphan.
- In this PR, the system will link the file to a document once the document is inserted in the system