### PR TITLE
fix: Fixes an Permission issue with User rename

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -376,10 +376,10 @@ class User(Document):
 					(tab, field, '%s', field, '%s'), (new_name, old_name))
 
 		if frappe.db.exists("Chat Profile", old_name):
-			frappe.rename_doc("Chat Profile", old_name, new_name, force=True)
+			frappe.rename_doc("Chat Profile", old_name, new_name, force=True, ignore_permissions=True)
 
 		if frappe.db.exists("Notification Settings", old_name):
-			frappe.rename_doc("Notification Settings", old_name, new_name, force=True)
+			frappe.rename_doc("Notification Settings", old_name, new_name, force=True, ignore_permissions=True)
 
 		# set email
 		frappe.db.sql("""UPDATE `tabUser`


### PR DESCRIPTION
[fix] Fixes a permission issue that prevented a 'user' record from being renamed if the user does not have write permissions for 'Chat Profile' and 'Notification Settings'.

If a 'user' record is renamed, the system tried updating the user's new email in 'Chat Profile' and 'Notification Settings' after rename. While doing this the system should ignore the user's permissions for 'Chat Profile' and 'Notification Settings' and update the email irrespective.