### PR TITLE
fix: do not override link values with title

### DIFF
--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -90,4 +90,19 @@ def format_value(value, df=None, doc=None, currency=None, translated=False):
 		values = [v.get(link_field.fieldname, 'asdf') for v in value]
 		return ', '.join(values)
 
+	elif df.get("fieldtype") in ["Link", "Dynamic Link"]:
+		if not doc or not doc.get("__link_titles") or not df.options:
+			return value
+
+		doctype = df.options
+		if df.get("fieldtype") == "Dynamic Link":
+			if not df.parent:
+				return value
+
+			meta = frappe.get_meta(df.parent)
+			_field = meta.get_field(df.options)
+			doctype = _field.options
+
+		return doc.__link_titles.get("{0}::{1}".format(doctype, value), value)
+
 	return value

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -165,12 +165,19 @@ def get_rendered_template(doc, name=None, print_format=None, meta=None,
 
 def set_link_titles(doc):
 	# Replaces name with title of link field doctype
+	if not doc.get("__link_titles"):
+		setattr(doc, "__link_titles", {})
 
 	meta = frappe.get_meta(doc.doctype)
 	set_title_values_for_link_and_dynamic_link_fields(meta, doc)
 	set_title_values_for_table_and_multiselect_fields(meta, doc)
 
-def set_title_values_for_link_and_dynamic_link_fields(meta, doc):
+def set_title_values_for_link_and_dynamic_link_fields(meta, doc, parent_doc=None):
+	if parent_doc and not parent_doc.get("__link_titles"):
+		setattr(parent_doc, "__link_titles", {})
+	elif doc and not doc.get("__link_titles"):
+		setattr(doc, "__link_titles", {})
+
 	for field in meta.get_link_fields() + meta.get_dynamic_link_fields():
 		if not doc.get(field.fieldname):
 			continue
@@ -184,7 +191,11 @@ def set_title_values_for_link_and_dynamic_link_fields(meta, doc):
 			continue
 
 		link_title = frappe.get_cached_value(doctype, doc.get(field.fieldname), meta.title_field)
-		setattr(doc, field.fieldname, link_title)
+
+		if parent_doc:
+			parent_doc.__link_titles["{0}::{1}".format(doctype, doc.get(field.fieldname))] = link_title
+		elif doc:
+			doc.__link_titles["{0}::{1}".format(doctype, doc.get(field.fieldname))] = link_title
 
 def set_title_values_for_table_and_multiselect_fields(meta, doc):
 	for field in meta.get_table_fields():
@@ -193,7 +204,7 @@ def set_title_values_for_table_and_multiselect_fields(meta, doc):
 
 		_meta = frappe.get_meta(field.options)
 		for value in doc.get(field.fieldname):
-			set_title_values_for_link_and_dynamic_link_fields(_meta, value)
+			set_title_values_for_link_and_dynamic_link_fields(_meta, value, doc)
 
 def convert_markdown(doc, meta):
 	'''Convert text field values to markdown if necessary'''


### PR DESCRIPTION
- When rendering the print formats, the framework replaced link field values with title field.
- While doing so, it inadvertently modified the doc, which leads to a host of other issues 
    - eg: it becomes difficult to use db functions in jinja since the link field values are changed