### PR TITLE
fix: hide "Others" in Dashboard Charts

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -22,6 +22,7 @@
   "group_by_based_on",
   "aggregate_function_based_on",
   "number_of_groups",
+  "show_others",
   "column_break_6",
   "is_public",
   "heatmap_year",
@@ -297,9 +298,16 @@
    "fieldname": "or_filters_section",
    "fieldtype": "Section Break",
    "label": "OR Filters Section"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.number_of_groups >0",
+   "fieldname": "show_others",
+   "fieldtype": "Check",
+   "label": "Show Others"
   }
  ],
- "modified": "2021-07-04 23:21:32.844514",
+ "modified": "2021-08-18 00:56:32.023290",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -305,11 +305,14 @@ def get_group_by_chart_config(chart, filters, or_filters):
 
 	if data:
 		if chart.number_of_groups and chart.number_of_groups < len(data):
-			other_count = 0
-			for i in range(chart.number_of_groups - 1, len(data)):
-				other_count += data[i]['count']
-			data = data[0: chart.number_of_groups - 1]
-			data.append({'name': 'Other', 'count': other_count})
+			if chart.number_of_groups > 0 and chart.show_others:
+				other_count = 0
+				for i in range(chart.number_of_groups - 1, len(data)):
+					other_count += data[i]['count']
+				data = data[0: chart.number_of_groups - 1]
+				data.append({'name': 'Other', 'count': other_count})
+			else:
+				data = data[0: chart.number_of_groups]
 
 		chart_config = {
 			"labels": [item['name'] if item['name'] else 'Not Specified' for item in data],


### PR DESCRIPTION
The dashboard lets you limit the number of groups if Group By was used in charts. The omitted data was combined into a single group - 'Other'. This PR makes showing 'Other' a configuration so that it can be removed if not wanted. 

<img width="748" alt="Screenshot 2021-08-18 at 1 54 24 PM" src="https://user-images.githubusercontent.com/8401344/129864446-b03b5d11-bcf1-46fd-8ed0-1ef0084cc351.png">

<img width="587" alt="Screenshot 2021-08-18 at 1 55 25 PM" src="https://user-images.githubusercontent.com/8401344/129864538-03c9dc40-f458-4438-b236-6d2efe6564ce.png">

<img width="593" alt="Screenshot 2021-08-18 at 1 55 55 PM" src="https://user-images.githubusercontent.com/8401344/129864603-153ccaf6-c7d0-4634-bae8-bf80e824355a.png">
