### PR TITLE
fix: filter out None values in Group By Dashboard Charts

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -24,7 +24,7 @@ if sys.version[0] == '2':
 	sys.setdefaultencoding("utf-8")
 
 __frappe_version__ = '12.8.1'
-__version__ = '2.4.0'
+__version__ = '2.5.0'
 __title__ = "Frappe Framework"
 
 local = Local()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -24,7 +24,7 @@ if sys.version[0] == '2':
 	sys.setdefaultencoding("utf-8")
 
 __frappe_version__ = '12.8.1'
-__version__ = '2.5.0'
+__version__ = '2.4.0'
 __title__ = "Frappe Framework"
 
 local = Local()

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -291,7 +291,7 @@ def get_group_by_chart_config(chart, filters, or_filters):
 	doctype = chart.document_type
 
 	# don't include documents where Group By Based On has Null values 
-	filters.append([chart.document_type, chart.group_by_based_on, "!=",""])
+	filters.append([doctype, group_by_field, "!=", ""])
 	
 	data = frappe.db.get_list(
 		doctype,

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -290,6 +290,9 @@ def get_group_by_chart_config(chart, filters, or_filters):
 	group_by_field = chart.group_by_based_on
 	doctype = chart.document_type
 
+	# don't include documents where Group By Based On has Null values 
+	filters.append([chart.document_type, chart.group_by_based_on, "!=",""])
+	
 	data = frappe.db.get_list(
 		doctype,
 		fields = [


### PR DESCRIPTION
<img width="587" alt="Screenshot 2021-08-18 at 2 51 41 PM" src="https://user-images.githubusercontent.com/8401344/129873108-7f57df8b-98e0-4642-8320-8b4bb9b871ec.png">
 This PR removes the 'Not Specified' bar