### PR TITLE
fix: floating image issue in blog detail page

### DIFF
--- a/frappe/public/css/blogdetail.css
+++ b/frappe/public/css/blogdetail.css
@@ -31,11 +31,6 @@ header {
     padding: 50px 70px;
 }
 
-.blog-content img{
-    float: left;
-    margin-right: 35px;
-}
-
 .blog-container hr {
     border-top: 1px solid #8d99a6;
 }


### PR DESCRIPTION
Screenshot:
Before:
![screenshot-bloomstack garden-2021 08 18-14_50_01](https://user-images.githubusercontent.com/45919049/129872934-6060d7d4-a046-4f1d-a8b7-c5ab3b577878.png)

After:
![screenshot-bloomstack garden-2021 08 18-14_50_27](https://user-images.githubusercontent.com/45919049/129872958-2ce02cd8-4576-459d-8b2c-091facfd5e6f.png)
