### PR TITLE
fix: email address validation and expire old emails in email queue

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -16,6 +16,7 @@ from rq.timeouts import JobTimeoutException
 from frappe.utils.scheduler import log
 from six import text_type, string_types, PY3
 from email.parser import Parser
+from frappe.utils import validate_email_address
 
 
 class EmailLimitCrossedError(frappe.ValidationError): pass
@@ -27,7 +28,6 @@ def send(recipients=None, sender=None, subject=None, message=None, text_content=
 		queue_separately=False, is_notification=False, add_unsubscribe_link=1, inline_images=None,
 		header=None, print_letterhead=False):
 	"""Add email to sending queue (Email Queue)
-
 	:param recipients: List of recipients.
 	:param sender: Email sender.
 	:param subject: Email subject.
@@ -324,7 +324,7 @@ def unsubscribe(doctype, name, email):
 
 def return_unsubscribed_page(email, doctype, name):
 	frappe.respond_as_web_page(_("Unsubscribed"),
-		_("You have successfully unsubscribed"),
+		_("{0} has left the conversation in {1} {2}").format(email, _(doctype), name),
 		indicator_color='green')
 
 def flush(from_test=False):
@@ -381,7 +381,7 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 		for update''', email, as_dict=True)[0]
 
 	recipients_list = frappe.db.sql('''select name, recipient, status from
-		`tabEmail Queue Recipient` where parent=%s''',email.name,as_dict=1)
+		`tabEmail Queue Recipient` where parent=%s''', email.name, as_dict=1)
 
 	if frappe.are_emails_muted():
 		frappe.msgprint(_("Emails are muted"))
@@ -401,13 +401,27 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 	if email.communication:
 		frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
 
+	email_sent_to_any_recipient = None
+
 	try:
+		message = None
+
 		if not frappe.flags.in_test:
-			if not smtpserver: smtpserver = SMTPServer()
+			if not smtpserver:
+				smtpserver = SMTPServer()
+
+			# to avoid always using default email account for outgoing
+			if getattr(frappe.local, "outgoing_email_account", None):
+				frappe.local.outgoing_email_account = {}
+
 			smtpserver.setup_email_account(email.reference_doctype, sender=email.sender)
 
 		for recipient in recipients_list:
 			if recipient.status != "Not Sent":
+				continue
+
+			if not validate_email_address(recipient.recipient):
+				recipient.status = "Error"
 				continue
 
 			message = prepare_message(email, recipient.recipient, recipients_list)
@@ -418,13 +432,19 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 			frappe.db.sql("""update `tabEmail Queue Recipient` set status='Sent', modified=%s where name=%s""",
 				(now_datetime(), recipient.name), auto_commit=auto_commit)
 
+		email_sent_to_any_recipient = any("Sent" == s.status for s in recipients_list)
+		email_sent_to_all_recipients = all("Sent" == s.status for s in recipients_list)
+
 		#if all are sent set status
-		if any("Sent" == s.status for s in recipients_list):
+		if email_sent_to_all_recipients:
 			frappe.db.sql("""update `tabEmail Queue` set status='Sent', modified=%s where name=%s""",
+				(now_datetime(), email.name), auto_commit=auto_commit)
+		elif email_sent_to_any_recipient:
+			frappe.db.sql("""update `tabEmail Queue` set status='Partially Sent', modified=%s where name=%s""",
 				(now_datetime(), email.name), auto_commit=auto_commit)
 		else:
 			frappe.db.sql("""update `tabEmail Queue` set status='Error', error=%s
-				where name=%s""", ("No recipients to send to", email.name), auto_commit=auto_commit)
+				where name=%s""", ("No valid recipients to send to", email.name), auto_commit=auto_commit)
 		if frappe.flags.in_test:
 			frappe.flags.sent_mail = message
 			return
@@ -440,7 +460,7 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 
 		# bad connection/timeout, retry later
 
-		if any("Sent" == s.status for s in recipients_list):
+		if email_sent_to_any_recipient:
 			frappe.db.sql("""update `tabEmail Queue` set status='Partially Sent', modified=%s where name=%s""",
 				(now_datetime(), email.name), auto_commit=auto_commit)
 		else:
@@ -460,7 +480,7 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 			frappe.db.sql("""update `tabEmail Queue` set status='Not Sent', modified=%s, retry=retry+1 where name=%s""",
 				(now_datetime(), email.name), auto_commit=auto_commit)
 		else:
-			if any("Sent" == s.status for s in recipients_list):
+			if email_sent_to_any_recipient:
 				frappe.db.sql("""update `tabEmail Queue` set status='Partially Errored', error=%s where name=%s""",
 					(text_type(e), email.name), auto_commit=auto_commit)
 			else:
@@ -576,4 +596,4 @@ def clear_outbox():
 		SET `status`='Expired'
 		WHERE `modified` < (NOW() - INTERVAL '7' DAY)
 		AND `status`='Not Sent'
-		AND (`send_after` IS NULL OR `send_after` < %(now)s)""", { 'now': now_datetime() })
+		AND (`send_after` IS NULL OR `send_after` < %(now)s)""", {'now': now_datetime()})

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -204,7 +204,8 @@ scheduler_events = {
 		"frappe.integrations.doctype.google_contacts.google_contacts.sync",
 		"frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat_entry",
 		"frappe.automation.doctype.auto_repeat.auto_repeat.set_auto_repeat_as_completed",
-		"frappe.email.doctype.unhandled_email.unhandled_email.remove_old_unhandled_emails"
+		"frappe.email.doctype.unhandled_email.unhandled_email.remove_old_unhandled_emails",
+		"frappe.email.doctype.email_queue.email_queue.expire_undelivered_emails"
 	],
 	"daily_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",


### PR DESCRIPTION
Fixes:
- Email Address validation in Email Queue while sending the email.
- Mark the Emails in Email Queue as `Error` if the emails are not delivered within **24 hours**