### PR TITLE
fix: fixed two test cases of salary slip module

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -119,7 +119,7 @@ def date_diff(string_ed_date, string_st_date):
 def month_diff(string_ed_date, string_st_date):
 	ed_date = getdate(string_ed_date)
 	st_date = getdate(string_st_date)
-	return (ed_date.year - st_date.year) * 12 + ed_date.month - st_date.month
+	return (ed_date.year - st_date.year) * 12 + ed_date.month - st_date.month + 1
 
 def time_diff(string_ed_date, string_st_date):
 	return get_datetime(string_ed_date) - get_datetime(string_st_date)


### PR DESCRIPTION
Fixed two test cases of the Salary slip module

1. test_tax_for_payroll_period (erpnext.hr.doctype.salary_slip.test_salary_slip.TestSalarySlip)
![image](https://user-images.githubusercontent.com/53329367/130943701-c7132943-dee0-4edd-bfa9-e18916882485.png)

2. test_payment_days (erpnext.hr.doctype.salary_slip.test_salary_slip.TestSalarySlip)
![image](https://user-images.githubusercontent.com/53329367/130943753-8ee43e39-9fac-479f-a445-026e15bb2c16.png)
