### PR TITLE
chore: move notification_badges_settings doctype from bloomstack_core to frappe

### DIFF
--- a/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.js
+++ b/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Notification Badges Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.json
+++ b/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.json
@@ -1,0 +1,39 @@
+{
+ "creation": "2019-11-04 23:33:31.286304",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "configuration"
+ ],
+ "fields": [
+  {
+   "fieldname": "configuration",
+   "fieldtype": "Table",
+   "label": "Configuration",
+   "options": "Notification Badges Settings Configuration"
+  }
+ ],
+ "issingle": 1,
+ "modified": "2021-09-15 00:45:49.187234",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Notification Badges Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.py
+++ b/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.py
@@ -3,8 +3,29 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+
+import json
+
+import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils.html_utils import is_json
+
 
 class NotificationBadgesSettings(Document):
-	pass
+	def validate(self):
+		for config in self.configuration:
+			self.validate_filter_json(config)
+			self.validate_filter_attributes(config)
+
+		frappe.clear_cache()
+
+	def validate_filter_json(self, row):
+		if not is_json(row.filter):
+			frappe.throw(_("Row {0}: The filter's JSON format is invalid".format(row.idx)))
+
+	def validate_filter_attributes(self, row):
+		notification_filter = json.loads(row.filter)
+		for attr in notification_filter:
+			if not hasattr(frappe.get_meta(row.filter_doctype), attr):
+				frappe.throw(_("Row {0}: '{1}' is not a valid attribute in {2}").format(row.idx, attr, row.filter_doctype))

--- a/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.py
+++ b/frappe/desk/doctype/notification_badges_settings/notification_badges_settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class NotificationBadgesSettings(Document):
+	pass

--- a/frappe/desk/doctype/notification_badges_settings/test_notification_badges_settings.py
+++ b/frappe/desk/doctype/notification_badges_settings/test_notification_badges_settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestNotificationBadgesSettings(unittest.TestCase):
+	pass


### PR DESCRIPTION
move notification_badges_settings doctype from bloomstack_Core to frappe DESK module
https://bloomstack.com/desk#Form/Task/TASK-2021-00272
https://github.com/Bloomstack/bloomstack_core/pull/709