### PR TITLE
chore: move notification_badges_settings_config doctype from bloomstack_core to frappe

### DIFF
--- a/frappe/desk/doctype/notification_badges_settings_configuration/notification_badges_settings_configuration.json
+++ b/frappe/desk/doctype/notification_badges_settings_configuration/notification_badges_settings_configuration.json
@@ -1,0 +1,49 @@
+{
+ "creation": "2019-11-06 22:42:38.117992",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "filter_doctype",
+  "filter",
+  "column_break_3",
+  "html_4"
+ ],
+ "fields": [
+  {
+   "fieldname": "filter_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "DocType",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "filter",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Filter",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "html_4",
+   "fieldtype": "HTML",
+   "options": "<p><strong>Filter Examples</strong></p>\n<pre>{\"status\": \"Open\"}<br>\n<br>{\"status\": [\"in\", [\"Open\", \"Overdue\"]]}<br>\n<br>{\"status\": [\"not in\", [\"Completed\", \"Closed\"]],\n\"docstatus\": [\"&lt;\", 2]}\n</pre>"
+  }
+ ],
+ "istable": 1,
+ "modified": "2021-09-15 00:55:36.316195",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Notification Badges Settings Configuration",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/desk/doctype/notification_badges_settings_configuration/notification_badges_settings_configuration.py
+++ b/frappe/desk/doctype/notification_badges_settings_configuration/notification_badges_settings_configuration.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class NotificationBadgesSettingsConfiguration(Document):
+	pass


### PR DESCRIPTION
move notification_badges_settings_config doctype from bloomstack_Core to frappe DESK module
https://bloomstack.com/desk#Form/Task/TASK-2021-00272
https://github.com/Bloomstack/bloomstack_core/pull/710