### PR TITLE
chore: move notificatons from bloomstack_core to frappe

### DIFF
--- a/frappe/core/notifications.py
+++ b/frappe/core/notifications.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 import frappe
+import json
 
 def get_notification_config():
-	return {
+	notifications = {
 		"for_doctype": {
 			"Error Log": {"seen": 0},
 			"Communication": {"status": "Open", "communication_type": "Communication"},
@@ -13,8 +14,15 @@ def get_notification_config():
 			"Event": "frappe.core.notifications.get_todays_events",
 			"Error Snapshot": {"seen": 0, "parent_error_snapshot": None},
 			"Workflow Action": {"status": 'Open'}
-		},
+		}
 	}
+
+	if frappe.db.exists("Notification Badges Settings"):
+		settings = frappe.get_single("Notification Badges Settings")
+		for config in settings.configuration:
+			notifications["for_doctype"][config.filter_doctype] = json.loads(config.filter)
+
+	return notifications
 
 def get_things_todo(as_list=False):
 	"""Returns a count of incomplete todos"""


### PR DESCRIPTION
**Task ID**: https://bloomstack.com/desk#Form/Task/TASK-2021-00282
**Description**: Move notifications.py notification from core to frappe
**Tested**: Yes
**Gif Added**: ![Peek 2021-09-20 18-03](https://user-images.githubusercontent.com/6947417/134002930-5b166450-ba3c-4791-b3ab-186c64d17bd1.gif)
**Dependency PR**: https://github.com/Bloomstack/frappe/pull/754 (Merged)
**Bloomstack Core PR**: https://github.com/Bloomstack/bloomstack_core/pull/738