### PR TITLE
chore:  moved query_report.js from bloomstack_core to erpnext

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -299,7 +299,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			filters.prepared_report_name = query_params.prepared_report_name;
 		}
 
-		return new Promise(resolve => {
+		let queryPromise = new Promise(resolve => {
 			this.last_ajax = frappe.call({
 				method: 'frappe.desk.query_report.run',
 				type: 'GET',
@@ -361,6 +361,23 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.show_footer_message();
 			frappe.hide_progress();
 		});
+
+		this.toggle_message(false);
+		frappe.dom.freeze("<img src='/assets/frappe/images/bloomstack_loader_infinity.svg'>");
+
+		return queryPromise.then((result) => {
+			this.cleanup();
+			return result;
+		}).catch((err) => {
+			this.cleanup();
+			throw err;
+		});
+
+	}
+
+	cleanup() {
+		// unfreeze the screen when query is complete
+		while (frappe.dom.freeze_count > 0) frappe.dom.unfreeze();
 	}
 
 	get_query_params() {


### PR DESCRIPTION
**Task Link:** https://bloomstack.com/desk#Form/Task/TASK-2021-00278

**Bloomstack_core PR:** https://github.com/Bloomstack/bloomstack_core/pull/748

**GIF**

- Before
![before-query-report](https://user-images.githubusercontent.com/53329367/134294109-ed10ceea-2fbf-4549-a69b-791c715d0818.gif)

- After
![after-query-report](https://user-images.githubusercontent.com/53329367/134294088-72ded550-1a0b-46ef-a67e-b9dd9ddd4c1c.gif)
