### PR TITLE
feat: custom database port for read-only replica configuration

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -195,12 +195,13 @@ def connect_replica():
 	from frappe.database import get_db
 	user = local.conf.db_name
 	password = local.conf.db_password
+	port = local.conf.replica_db_port
 
 	if local.conf.different_credentials_for_replica:
 		user = local.conf.replica_db_name
 		password = local.conf.replica_db_password
 
-	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password)
+	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
 
 	# swap db connections
 	local.primary_db = local.db


### PR DESCRIPTION
Able to use custom port for database load balancers.
By adding following key to site_config.json

| | |
| ----------- | ----------- |
| read_from_replica | To enable disable read from replica. Acceptable values are 1/0 or true/false. |
| different_credentials_for_replica | If database credentials are different on replica then set 1 else 0 |
| replica_host` | IP address for replica |
| replica_db_name | Replica DB name |
| replica_db_password | Replica DB password |
| **`replica_db_port`** | **Replica DB port number** |