### PR TITLE
fix: bulk delete grid items sequentially

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -140,10 +140,10 @@ export default class Grid {
 						me.df.data = me.get_data();
 						me.df.data = me.df.data.filter((row)=> row.idx != doc.idx);
 					}
-					me.grid_rows_by_docname[doc.name].remove();
 					dirty = true;
+					return me.grid_rows_by_docname[doc.name] && me.grid_rows_by_docname[doc.name].remove();
 				});
-				tasks.push(() => frappe.timeout(0.1));
+				tasks.push(() => frappe.timeout(0));
 			});
 
 			if (!me.frm) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -65,7 +65,7 @@ export default class GridRow {
 					this.hide_form();
 				}
 
-				frappe.run_serially([
+				return frappe.run_serially([
 					() => {
 						return this.frm.script_manager.trigger("before_" + this.grid.df.fieldname + "_remove",
 							this.doc.doctype, this.doc.name);
@@ -73,8 +73,10 @@ export default class GridRow {
 					() => {
 						frappe.model.clear_doc(this.doc.doctype, this.doc.name);
 
-						this.frm.script_manager.trigger(this.grid.df.fieldname + "_remove",
+						return this.frm.script_manager.trigger(this.grid.df.fieldname + "_remove",
 							this.doc.doctype, this.doc.name);
+					},
+					() => {
 						this.frm.dirty();
 						this.grid.refresh();
 					},


### PR DESCRIPTION
**Traceback/Bug Report**
Currently while bulk deleting grid items each row is deleted asynchronously. Which can break when we have a large number of rows.

![bulk_delete_issue](https://user-images.githubusercontent.com/37302950/135842407-b5294531-d46f-4205-8227-3696121f40c2.gif)

**Fixes:**
This PR refactor the code to return the async function for the sequential execution happening in `remove()` function.