### PR TITLE
perf: speed up link validation

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -544,7 +544,7 @@ class Database(object):
 		"""
 
 		if not doctype in self.value_cache:
-			self.value_cache = self.value_cache[doctype] = {}
+			self.value_cache[doctype] = {}
 
 		if fieldname in self.value_cache[doctype]:
 			return self.value_cache[doctype][fieldname]


### PR DESCRIPTION
### Problem:

- db.value_cache is erased every time get_single_value is called and doctype is not found in cache.
- This causes an endless loop of erasing and recreating it if two different single doctype values are requested in a transaction, which essentially make this cache useless overhead.

eg:
```
for sle in sles:
    a = frappe.db.get_single_value("Stock Setting", "allow_negative_stock") # this cleared the cache
    b = frappe.db.get_single_value("Account Setting", "frozen_upto") # this cleared the cache again
```

### Solution:

- Temp fix: Don't erase the whole cache, just initiate new dictionary for missing doctype.

Results:

Example: Stock entry with ~100 items submitted twice after full cold restart.

~20-25% reduction in repeated queries. ~20-25% reduction in query time.

Before:
![image](https://user-images.githubusercontent.com/37302950/135844204-4bb77978-5cfc-4e78-a5f6-5c0c7f0d5cc3.png)

After:
![image](https://user-images.githubusercontent.com/37302950/135844242-6f1a282e-b3e0-4b68-a498-02431fdf0ab3.png)

repeated queries before (you can identify that these are all link validation queries):
![image](https://user-images.githubusercontent.com/37302950/135844296-b21b599d-76bc-4d82-85eb-2241ccf59fb0.png)

Repeated queries after:
![image](https://user-images.githubusercontent.com/37302950/135844337-8c0ce6db-1539-4fe6-91a4-129c2089b465.png)

prun cumulative, again both are from cold start.

Before:
```
         17314183 function calls (17062515 primitive calls) in 18.350 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    181/1    0.001    0.000   18.350   18.350 {built-in method builtins.exec}
    100/1    0.000    0.000   18.350   18.350 document.py:927(submit)
    100/1    0.000    0.000   18.350   18.350 document.py:915(_submit)
    199/1    0.000    0.000   18.350   18.350 document.py:280(save)
    199/1    0.007    0.000   18.350   18.350 document.py:284(_save)
  2792/15    0.031    0.000   16.988    1.133 document.py:848(run_method)
  2792/15    0.025    0.000   16.809    1.121 document.py:1140(composer)
  2792/15    0.017    0.000   16.791    1.119 document.py:1131(runner)
    501/3    0.002    0.000   16.516    5.505 document.py:854(<lambda>)
    299/1    0.007    0.000   12.864   12.864 document.py:984(run_post_save_methods)
        1    0.000    0.000   12.519   12.519 stock_entry.py:94(on_submit)

	---- clipped to keep relevant output ---

      299    0.002    0.000    1.791    0.006 document.py:815(_validate_links)
      398    0.042    0.000    1.760    0.004 base_document.py:522(get_invalid_links)
```

After:
```
         13107176 function calls (12879255 primitive calls) in 15.092 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    205/1    0.001    0.000   15.092   15.092 {built-in method builtins.exec}
    100/1    0.000    0.000   15.092   15.092 document.py:927(submit)
    100/1    0.000    0.000   15.092   15.092 document.py:915(_submit)
    199/1    0.000    0.000   15.092   15.092 document.py:280(save)
    199/1    0.007    0.000   15.092   15.092 document.py:284(_save)
  2792/15    0.031    0.000   14.208    0.947 document.py:848(run_method)
  2792/15    0.027    0.000   14.190    0.946 document.py:1140(composer)
  2792/15    0.018    0.000   14.167    0.944 document.py:1131(runner)
    501/3    0.002    0.000   14.149    4.716 document.py:854(<lambda>)
    299/1    0.007    0.000   12.607   12.607 document.py:984(run_post_save_methods)
        1    0.000    0.000   12.504   12.504 stock_entry.py:94(on_submit)

	---- clipped to keep relevant output ---

      299    0.002    0.000    0.541    0.002 document.py:815(_validate_links)
2679/1395    0.014    0.000    0.531    0.000 base_document.py:305(as_dict)
     7806    0.013    0.000    0.528    0.000 _compat.py:71(recv)
      197    0.001    0.000    0.524    0.003 stock_ledger.py:832(get_previous_sle)
      197    0.002    0.000    0.523    0.003 stock_ledger.py:850(get_stock_ledger_entries)
     7806    0.516    0.000    0.516    0.000 {method 'recv' of '_socket.socket' objects}
      398    0.034    0.000    0.510    0.001 base_document.py:522(get_invalid_links)
```