### PR TITLE
fix: moving sites folder across different filesystems

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -495,7 +495,7 @@ def move(dest_dir, site):
 		site_dump_exists = os.path.exists(final_new_path)
 		count = int(count or 0) + 1
 
-	os.rename(old_path, final_new_path)
+	shutil.move(old_path, final_new_path)
 	frappe.destroy()
 	return final_new_path
 


### PR DESCRIPTION
**Scenario:**
Production app using Docker images from [frappe_docker](https://github.com/frappe/frappe_docker)
bench_manager installer

**Issue:**
Drop site which is created by bench_manager result in OSError: [Errno 18] Invalid cross-device link

**Root cause:**
The docker container backing file system is different from the host's file system, so moving the site to archived folder failed.

**Solution:**
Use shutil.move instead since it not use "link" and take care of the filesystem differences ( tested )