### PR TITLE
fix: display of numbers in number card if type is report

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -214,7 +214,7 @@ export default class NumberCardWidget extends Widget {
 		}, []);
 		const col = res.columns.find(col => col.fieldname == field);
 		this.number = frappe.report_utils.get_result_of_fn(this.card_doc.report_function, vals);
-		this.get_formatted_number(col);
+		this.formatted_number = this.number;
 	}
 
 	get_formatted_number(df) {


### PR DESCRIPTION
- [x] Fixes

<h3>Traceback/Bug Report:</h3> 
Number was not showing on number card in Dashboard if Number card was of type Report

It was because of the function that was trying to format number docfield properties and report does not have that.

<h3>Steps to replicate:</h3> 

Step 1: Create Number card with type Report
Step 2: Add it to dashboard (Number will not display in number card on dashboard) 

<h3>Expected Behaviour/Fixes :</h3> 
Now it displays Proper Number in Dashboard

![screenshot-bloomstack_demo_8000-2021 10 13-17_49_36](https://user-images.githubusercontent.com/53251406/137131172-4f4f0522-e7a0-496a-9a32-e80c0e3607a7.jpg)

