### PR TITLE
fix: route to parent list if dashboard number card is based on child table

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -66,30 +66,38 @@ export default class NumberCardWidget extends Widget {
 
 	set_events() {
 		$(this.body).click(() => {
-			if (this.in_customize_mode || this.card_doc.type == 'Custom') return;
+			if (this.in_customize_mode || this.card_doc.type == 'Custom' || this.card_doc.type == 'Script') return;
 			this.set_route();
 		});
 	}
 
 	set_route() {
 		const is_document_type = this.card_doc.type !== 'Report';
-		const name = is_document_type ? this.card_doc.document_type : this.card_doc.report_name;
-		const route = frappe.utils.generate_route({
-			name: name,
-			type: is_document_type ? 'doctype' : 'report',
-			is_query_report: !is_document_type,
+		frappe.model.with_doctype(this.card_doc.document_type, () => {
+			let is_child = frappe.get_meta(this.card_doc.document_type).istable;
+			let name;
+			if (is_child) {
+				let doc = frappe.get_doc("DocField", {"fieldtype": "Table", "options": this.card_doc.document_type});
+				name = doc.parent ? doc.parent : "";
+			} else {
+				name = is_document_type ? this.card_doc.document_type : this.card_doc.report_name;
+			}
+			const route = frappe.utils.generate_route({
+				name: name,
+				type: is_document_type ? 'doctype' : 'report',
+				is_query_report: !is_document_type,
+			});
+			if (is_document_type) {
+				const filters = JSON.parse(this.card_doc.filters_json);
+				frappe.route_options = filters.reduce((acc, filter) => {
+					return Object.assign(acc, {
+						[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]]
+					});
+				}, {});
+			}
+
+			frappe.set_route(route);
 		});
-
-		if (is_document_type) {
-			const filters = JSON.parse(this.card_doc.filters_json);
-			frappe.route_options = filters.reduce((acc, filter) => {
-				return Object.assign(acc, {
-					[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]]
-				});
-			}, {});
-		}
-
-		frappe.set_route(route);
 	}
 
 	set_doc_args() {


### PR DESCRIPTION
<h3>Traceback/Bug Report:</h3>  
If Number card is based on child table it was trying to open child table list which was giving error

<h3>Expected Behaviour/Fixes:</h3> 
Route to parent list if Number card is based on child table

![number-card](https://user-images.githubusercontent.com/53251406/138221550-6a19f49e-4fa8-42d9-83d3-7bbf79944e48.gif)

