### PR TITLE
fix: set no copy to 1 for password field in Email Account

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -81,7 +81,8 @@
   {
    "fieldname": "password",
    "fieldtype": "Password",
-   "label": "Password"
+   "label": "Password",
+   "no_copy": 1
   },
   {
    "default": "0",
@@ -399,7 +400,7 @@
   }
  ],
  "icon": "fa fa-inbox",
- "modified": "2020-05-20 15:35:53.851057",
+ "modified": "2021-11-09 22:42:51.137963",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",


### PR DESCRIPTION
Issue : https://bloomstack.com/desk#Form/Issue/ISS-2021-00313

While Duplicating Email Account and saving form, it used to logout directly.

Behavior After Fix:
It does not copy password While Duplicating Email Account. 